### PR TITLE
Improve execution plan approval gate clarity

### DIFF
--- a/docs/history/nefario-reports/2026-02-10-170603-improve-exec-plan-approval-gate.md
+++ b/docs/history/nefario-reports/2026-02-10-170603-improve-exec-plan-approval-gate.md
@@ -1,0 +1,213 @@
+---
+type: nefario-report
+version: 2
+date: "2026-02-10"
+time: "17:06:03"
+task: "Improve execution plan approval gate clarity"
+mode: full
+agents-involved: [ux-strategy-minion, devx-minion, software-docs-minion, security-minion, test-minion, lucy, margo]
+task-count: 4
+gate-count: 2
+outcome: completed
+---
+
+# Improve execution plan approval gate clarity
+
+## Summary
+
+Defined a structured execution plan approval gate format that presents the full plan with self-contained advisory context at the Phase 3.5/Phase 4 boundary. The gate uses progressive disclosure (orientation, task list, advisories, reference) with a two-field delta model (CHANGE/WHY) for advisories, enabling informed approve/reject decisions without cross-referencing session history.
+
+## Original Prompt
+
+> Improve execution plan approval gate clarity
+>
+> **Outcome**: The execution plan approval gate shows the full execution plan and provides enough context for each incorporated advisory that the user can make an informed approve/reject decision without hunting through session history. Currently the gate is opaque -- it omits the plan and lists advisory summaries that are meaningless without their original context.
+>
+> **Success criteria**:
+> - Execution plan is displayed in full at the approval gate
+> - Each incorporated ADVISE verdict includes enough context to understand what it means and why it was adopted (not just a cryptic one-liner referencing task numbers)
+> - User can approve or reject the execution plan based solely on what the gate presents, without needing to cross-reference session IDs or prior phases
+>
+> **Scope**:
+> - In: Nefario SKILL.md gate formatting, AGENT.md execution plan presentation logic
+> - Out: Other gates (meta-plan, synthesis), phase ordering, verdict format changes, AGENT.generated.md/overrides.md rebuild
+
+## Decisions
+
+#### Progressive Disclosure over Flat Dump
+
+**Rationale**:
+- Users need anomaly detection (spotting surprises), not comprehensive reading
+- Progressive disclosure lets users scan at their preferred depth
+- Flat dump of the full synthesis would exceed usable terminal output
+
+**Alternatives Rejected**:
+- Full synthesis dump: too long, buries important signals in implementation detail
+- Summary-only: insufficient context for informed decisions
+
+#### Two-Field Advisory Delta (CHANGE/WHY)
+
+**Rationale**:
+- Two fields (CHANGE, WHY) provide enough context for approval decisions
+- ORIGINAL field was considered and rejected -- adds complexity without proportional value
+- Domain attribution (testing, security) is more meaningful than agent attribution (test-minion)
+
+**Alternatives Rejected**:
+- Three-field model (CHANGE/WHY/ORIGINAL): unnecessary complexity per margo review
+- Agent-attributed advisories: the concern domain matters more than which agent raised it
+
+#### Three Response Options (No Skip)
+
+**Rationale**:
+- Plan-level gate requires a definitive decision before execution begins
+- "Skip" (defer review) makes sense for individual deliverables, not entire plans
+- Keeps cognitive load low at the highest-stakes decision point
+
+**Gate outcome**: approved
+**Confidence**: HIGH
+
+**Conflict Resolutions**:
+- Gate options (3 vs 4): ux-strategy-minion proposed 4 options including "Approve with deployment." Resolved in favor of 3 -- deployment opt-in is a separate decision handled post-execution.
+- Advisory attribution (domain vs agent): ux-strategy-minion recommended domain attribution, devx-minion used agent names in examples. Resolved in favor of domain attribution.
+- Layer nomenclature (4 layers vs 2 tiers): Resolved to use plain section names with soft line budget guidance, avoiding both numbered layers and rigid tiers.
+
+## Agent Contributions
+
+<details>
+<summary>Agent Contributions (2 planning, 6 review)</summary>
+
+### Planning
+
+**ux-strategy-minion**: Designed progressive disclosure information architecture for anomaly detection; advisory delta model; cognitive load budget.
+- Adopted: Progressive disclosure sections, delta model for advisories, domain attribution
+- Risks flagged: Content overflow for complex plans (mitigated with advisory caps)
+
+**devx-minion**: Analyzed terminal constraints driving format decisions; recommended flat text over HTML; inline advisory blocks with context.
+- Adopted: Terminal-optimized format, flat text, compact task list format
+- Risks flagged: Advisory delta requires synthesis-time data (mitigated by adding fields to ADVISE verdict)
+
+### Architecture Review
+
+**security-minion**: APPROVE. No concerns.
+
+**test-minion**: ADVISE. Recommended verifiable assertions for gate format compliance; accepted as non-blocking.
+
+**ux-strategy-minion**: ADVISE. Recommended standardizing advisories as separate block (not inline) and specifying "Request changes" workflow; both adopted.
+
+**software-docs-minion**: ADVISE. Noted potential TEMPLATE.md updates needed; tracked as non-blocking follow-up.
+
+**lucy**: ADVISE. Justified scope expansion for Tasks 2 and 3 (communication protocol and ADVISE verdict format); both necessary for consistency.
+
+**margo**: ADVISE. Dropped "4-layer" nomenclature in favor of plain sections; reduced ADVISE fields from 3 to 2 (dropped ORIGINAL); both adopted.
+
+</details>
+
+## Execution
+
+### Files Created/Modified
+
+| File Path | Action | Description |
+|-----------|--------|-------------|
+| skills/nefario/SKILL.md | modified | Added Execution Plan Approval Gate section; updated communication protocol |
+| nefario/AGENT.md | modified | Added TASK/CHANGE fields to ADVISE verdict format |
+| docs/orchestration.md | modified | Added plan gate documentation; distinguished from mid-execution gates |
+
+### Approval Gates
+
+| Gate Title | Agent | Confidence | Outcome | Rounds |
+|------------|-------|------------|---------|--------|
+| Execution plan gate spec | nefario | HIGH | approved | 1 |
+| Task 1 deliverable | nefario | HIGH | approved | 1 |
+
+#### Execution Plan Gate Spec
+
+**Decision**: Progressive disclosure with two-field advisory delta, 3 response options, soft line budget.
+**Rationale**: Optimizes for anomaly detection at the highest-stakes decision point; balances context with brevity.
+**Rejected**: Flat synthesis dump, summary-only, 4 response options with deployment.
+
+#### Task 1 Deliverable
+
+**Decision**: Accept SKILL.md gate format section as core specification for remaining tasks.
+**Rationale**: Clean implementation matching all advisory-incorporated requirements; verified before proceeding.
+**Rejected**: N/A (first-round approval).
+
+## Process Detail
+
+<details>
+<summary>Process Detail</summary>
+
+### Phases Executed
+
+| Phase | Agents |
+|-------|--------|
+| Meta-plan | nefario |
+| Specialist Planning | ux-strategy-minion, devx-minion |
+| Synthesis | nefario |
+| Architecture Review | security-minion, test-minion, ux-strategy-minion, software-docs-minion, lucy, margo |
+| Execution | devx-minion (3 tasks), software-docs-minion (1 task) |
+| Code Review | (skipped -- specification and documentation changes only) |
+| Test Execution | (skipped -- no executable code) |
+| Deployment | (skipped -- not requested) |
+| Documentation | (covered by Task 4) |
+
+### Verification
+
+| Phase | Result |
+|-------|--------|
+| Code Review | (skipped -- spec/docs changes only) |
+| Test Execution | (skipped -- no executable code) |
+| Deployment | (skipped -- not requested) |
+| Documentation | 3 files modified |
+| Cross-file Consistency | Verified: SKILL.md gate format, AGENT.md ADVISE fields, orchestration.md references all align |
+
+### Timing
+
+| Phase | Duration |
+|-------|----------|
+| Meta-plan | ~2m |
+| Specialist Planning | ~5m |
+| Synthesis | ~4m |
+| Architecture Review | ~6m |
+| Execution | ~4m |
+| **Total** | **~21m** |
+
+### Outstanding Items
+
+- [ ] Consider TEMPLATE.md updates to document plan gate vs mid-execution gate in report format (non-blocking, flagged by software-docs-minion)
+
+</details>
+
+## Working Files
+
+<details>
+<summary>Working files (10 files)</summary>
+
+Companion directory: [2026-02-10-170603-improve-exec-plan-approval-gate/](./2026-02-10-170603-improve-exec-plan-approval-gate/)
+
+- [Original Prompt](./2026-02-10-170603-improve-exec-plan-approval-gate/prompt.md)
+- [Phase 1: Meta-plan](./2026-02-10-170603-improve-exec-plan-approval-gate/phase1-metaplan.md)
+- [Phase 2: ux-strategy-minion](./2026-02-10-170603-improve-exec-plan-approval-gate/phase2-ux-strategy-minion.md)
+- [Phase 2: devx-minion](./2026-02-10-170603-improve-exec-plan-approval-gate/phase2-devx-minion.md)
+- [Phase 3: Synthesis](./2026-02-10-170603-improve-exec-plan-approval-gate/phase3-synthesis.md)
+- [Phase 3.5: test-minion](./2026-02-10-170603-improve-exec-plan-approval-gate/phase3.5-test-minion.md)
+- [Phase 3.5: ux-strategy-minion](./2026-02-10-170603-improve-exec-plan-approval-gate/phase3.5-ux-strategy-minion.md)
+- [Phase 3.5: software-docs-minion](./2026-02-10-170603-improve-exec-plan-approval-gate/phase3.5-software-docs-minion.md)
+- [Phase 3.5: lucy](./2026-02-10-170603-improve-exec-plan-approval-gate/phase3.5-lucy.md)
+- [Phase 3.5: margo](./2026-02-10-170603-improve-exec-plan-approval-gate/phase3.5-margo.md)
+
+</details>
+
+## Metrics
+
+| Metric | Value |
+|--------|-------|
+| Date | 2026-02-10 |
+| Task | Improve execution plan approval gate clarity |
+| Duration | ~21m |
+| Outcome | completed |
+| Planning Agents | 2 agents consulted |
+| Review Agents | 6 reviewers |
+| Execution Agents | 2 agents spawned |
+| Gates Presented | 2 of 2 approved |
+| Files Changed | 0 created, 3 modified |
+| Outstanding Items | 1 item |

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -200,10 +200,10 @@ sequenceDiagram
 
     Note over Main: Scratch files written + compaction checkpoint
 
-    Main->>User: Present plan + advisories + gate map
+    Main->>User: Execution plan approval gate (task list + advisories)
 
     Note over User,Main: Plan Approval Gate
-    User->>Main: Approve / request changes / reject (structured prompt)
+    User->>Main: Approve / request changes / reject
 
     Note over Main,Exec: Phase 4: Execution (batch-gated)
     Main->>Main: Topological sort, identify batches
@@ -324,11 +324,44 @@ The checklist applies in all modes (META-PLAN, SYNTHESIS, PLAN). The default is 
 
 ## 3. Approval Gates
 
-Approval gates pause execution to get user input on a deliverable before downstream work proceeds. The mechanism is designed to gate high-impact decisions without creating approval fatigue.
+Approval gates pause execution to get user input before downstream work proceeds. The mechanism is designed to gate high-impact decisions without creating approval fatigue.
 
-### Gate Classification
+Two types of gates exist with distinct semantics:
 
-Gates are classified on two dimensions: **reversibility** (how hard is it to undo this decision?) and **blast radius** (how many downstream tasks depend on it).
+**Plan approval gate** -- Occurs once, after Phase 3.5 (Architecture Review) and before Phase 4 (Execution). The user reviews the complete execution plan (task list with incorporated advisories) and decides whether to approve, request changes, or reject the entire plan.
+
+**Mid-execution gates** -- Occur during Phase 4 at batch boundaries. Each gate covers a single deliverable that downstream tasks depend on. The user reviews the deliverable and decides whether to approve, request changes, reject, or skip (defer for later review).
+
+### Execution Plan Approval Gate
+
+The plan approval gate occurs after all architecture review verdicts are resolved and before any code execution begins. It serves as the final checkpoint before committing resources to implementation.
+
+**When it occurs**: After Phase 3.5 (Architecture Review), before Phase 4 (Execution).
+
+**Format**: Progressive disclosure optimized for anomaly detection. The user knows what they asked for; the gate helps them spot surprises. See `skills/nefario/SKILL.md` (Execution Plan Approval Gate section) for the complete specification. Key sections:
+
+- **Instant orientation** -- One-line goal summary plus task/gate/advisory counts
+- **Task list** -- Compact numbered list showing title, deliverable, dependencies, agent, and gate markers (2-4 lines per task)
+- **Advisories** -- Structured deltas (CHANGE, WHY) grouped by affected task, domain-attributed not agent-attributed, maximum 3 lines per advisory
+- **Risks and conflict resolutions** -- Identified risks with mitigations, contested decisions with rationales (omitted if none)
+- **Review summary** -- One-line approval/advise/block count
+- **Full plan reference** -- Path to complete synthesis output in scratch files
+
+**Line budget**: Target 25-40 lines for the complete gate output. Soft guidance -- clarity wins over brevity.
+
+**Advisory presentation**: Advisories use a delta model (what changed in the task, why the change was needed), not a reviewer opinion model. They are attributed to the domain (testing, security, usability, etc.), not the agent. This keeps the gate focused on plan changes rather than review process details.
+
+**Response options**: Three choices presented via `AskUserQuestion`:
+
+1. **Approve** -- Accept the plan and begin execution. Recommended default.
+2. **Request changes** -- Provide feedback on what needs revision. Nefario revises affected parts and re-presents the gate.
+3. **Reject** -- Abandon the plan entirely.
+
+Unlike mid-execution gates, there is no "Skip" option -- the plan must be approved or rejected before execution can proceed.
+
+### Gate Classification (Mid-Execution)
+
+Mid-execution gates are classified on two dimensions: **reversibility** (how hard is it to undo this decision?) and **blast radius** (how many downstream tasks depend on it).
 
 | | Low Blast Radius (0-1 dependents) | High Blast Radius (2+ dependents) |
 |---|---|---|
@@ -339,9 +372,9 @@ Gates are classified on two dimensions: **reversibility** (how hard is it to und
 
 Examples of MUST-gate tasks: database schema design, API contract definition, UX strategy recommendations, security threat model. Examples of no-gate tasks: CSS styling, test file organization, documentation formatting.
 
-### Decision Brief Format
+### Decision Brief Format (Mid-Execution)
 
-Decision briefs use three layers of progressive disclosure to respect the user's time:
+Mid-execution gates present individual deliverables using decision briefs with three layers of progressive disclosure to respect the user's time:
 
 **Layer 1 (5-second scan)**: One-sentence description of the decision.
 **Layer 2 (30-second read)**: Rationale with 3-5 bullets, including at least one rejected alternative and the reason it was rejected.
@@ -367,9 +400,9 @@ Confidence: HIGH | MEDIUM | LOW
 Decision points use Claude Code's `AskUserQuestion` tool for structured selection.
 ```
 
-### Response Handling
+### Response Handling (Mid-Execution)
 
-Gates present four options via structured prompt:
+Mid-execution gates present four options via structured prompt:
 
 - **Approve** -- Gate clears. A follow-up prompt offers "Run all" (post-execution phases) or "Skip post-execution". Downstream tasks are unblocked.
 - **Request changes** -- A follow-up message asks what changes are needed. The producing agent revises. Capped at 2 revision iterations. If still unsatisfied, the current state is presented with a summary of what was requested, changed, and unresolved. The user then decides to approve as-is, reject, or take over manually.

--- a/nefario/AGENT.md
+++ b/nefario/AGENT.md
@@ -490,14 +490,20 @@ Each reviewer returns exactly one verdict:
 **APPROVE** -- No concerns. The plan adequately addresses this reviewer's domain.
 
 **ADVISE** -- Non-blocking warnings. Advisories are appended to the relevant
-task prompts before execution and presented to the user alongside the plan.
-They do not block execution. Format:
+task prompts before execution and presented to the user at the execution plan
+approval gate. They do not block execution. Format:
 ```
 VERDICT: ADVISE
 WARNINGS:
 - [domain]: <description of concern>
+  TASK: <task number affected, e.g., "Task 3">
+  CHANGE: <what specifically changed in the task prompt or deliverables>
   RECOMMENDATION: <suggested change>
 ```
+
+The TASK and CHANGE fields enable the calling session to populate the execution
+plan approval gate with structured advisory data, showing which tasks were
+modified and what changed.
 
 **BLOCK** -- Halts execution. The reviewer has identified an issue serious enough
 that proceeding would create significant risk or rework. Resolution process:

--- a/skills/nefario/SKILL.md
+++ b/skills/nefario/SKILL.md
@@ -39,6 +39,7 @@ The workflow has nine phases:
 The orchestrator MUST minimize chat output. The user should only see:
 
 **SHOW** (these are the only things printed to chat):
+- Execution plan approval gate (task list, advisories, risks, review summary)
 - Approval gate decision briefs (full structured format)
 - PR creation prompt
 - Final summary (report path, PR URL, branch name)
@@ -60,7 +61,8 @@ The orchestrator MUST minimize chat output. The user should only see:
 **CONDENSE** to a single line:
 - Meta-plan result: "Planning: consulting devx-minion, security-minion, ..."
 - Review verdicts (if no BLOCK): "Review: 4 APPROVE, 0 BLOCK"
-- ADVISE notes: fold silently into relevant task prompts, do not print
+- ADVISE notes: fold into relevant task prompts. Show at execution plan
+  approval gate using advisory delta format. Do not print during mid-execution.
 - Post-execution start: "Verifying: code review, tests, documentation..."
 - Post-execution result: fold into wrap-up ("Verification: all checks passed" or "Verification: 2 findings auto-fixed, all tests pass, docs updated")
 
@@ -388,6 +390,118 @@ Skipping is fine if context is short. Risk: auto-compaction during execution may
 
 Same response handling: if user runs `/compact`, wait for "continue". If
 anything else, print the continuation message and proceed. Do NOT re-prompt.
+
+## Execution Plan Approval Gate
+
+After Phase 3.5 completes, present the execution plan to the user for approval
+using progressive disclosure optimized for anomaly detection. The user knows
+what they asked for; they need to spot surprises and decide whether to proceed.
+
+### Plan Presentation Format
+
+**Instant orientation** (one line + stats):
+```
+EXECUTION PLAN: <1-sentence goal summary>
+Tasks: N | Gates: N | Advisories incorporated: N
+```
+
+**Task list** (compact numbered list, 2-4 lines per task):
+```
+TASKS:
+  1. <Task title>                                    [agent-name, model]
+     Produces: <deliverable summary>
+     Depends on: none
+
+  2. <Task title>                                    [agent-name, model]
+     Produces: <deliverable summary>
+     Depends on: Task 1
+     GATE: Approval required before Tasks 3, 4 proceed
+```
+Format rules:
+- Title on line 1, metadata indented below
+- Agent name and model in brackets (secondary info, right side)
+- Dependencies by task number
+- GATE marker inline with the blocking task
+- One blank line between tasks, no blank lines within a task
+
+**Advisories** (presented as a SEPARATE block after task list):
+
+Advisories are plan changes (delta model), not reviewer opinions. Attribute to
+the DOMAIN (testing, security, usability, etc.), not the agent name.
+
+Format:
+```
+ADVISORIES:
+  [<domain>] Task N: <task title>
+    CHANGE: <one sentence describing the concrete change to the task>
+    WHY: <one sentence explaining the concern that motivated it>
+
+  [<domain>] Task M: <task title>
+    CHANGE: ...
+    WHY: ...
+```
+
+Advisory principles:
+- Two-field format (CHANGE, WHY) makes each advisory self-contained
+- Maximum 3 lines per advisory. If more complex, add:
+  "Details: nefario/scratch/{slug}/phase3.5-{reviewer}.md"
+- Maximum 5 advisories explained individually. Beyond 5, group related advisories
+- Beyond 7, the plan needs rework (too many course corrections)
+- If an advisory did NOT change the task (informational only), say:
+  "[domain]: <note>. No task changes."
+
+**Risks and conflict resolutions** (if any exist):
+```
+RISKS:
+  - <risk description> — Mitigation: <what the plan does about it>
+
+CONFLICTS RESOLVED:
+  - <what was contested>: Resolved in favor of <approach> because <rationale>
+```
+Omit if no conflicts. If no risks, note: "No risks identified by specialists."
+
+**Review summary** (one line):
+```
+REVIEW: N APPROVE, N ADVISE, N BLOCK
+```
+
+**Full plan reference**:
+```
+FULL PLAN: nefario/scratch/{slug}/phase3-synthesis.md
+```
+
+**Line budget guidance**: Target 25-40 lines for the complete gate output
+(orientation + task list + advisories + risks + review summary + plan reference).
+This is soft guidance, not a hard ceiling — clarity wins over brevity.
+
+### What NOT to Show
+
+Do not include at the plan approval gate:
+- Full agent prompts (implementation detail — in the scratch file)
+- Model selection (opus vs sonnet)
+- Mode selection (bypassPermissions, plan, default)
+- File ownership assignments
+- Cross-cutting coverage checklist (internal bookkeeping)
+- Architecture review agent list (the results matter, not who reviewed)
+
+### Decision Options
+
+Present the plan for approval using AskUserQuestion:
+- `header`: "Plan"
+- `question`: "<the orientation line goal summary>"
+- `options` (3, `multiSelect: false`):
+  1. label: "Approve", description: "Accept plan and begin execution." (recommended)
+  2. label: "Request changes", description: "Revise the plan before execution."
+  3. label: "Reject", description: "Abandon this plan entirely."
+
+### Request Changes Workflow
+
+When the user selects "Request changes":
+1. The user provides feedback on what to change
+2. Nefario revises the affected parts of the plan (may re-run synthesis for changed tasks)
+3. The gate is presented again with the updated plan
+
+After "Approve", proceed to Phase 4 execution.
 
 ## Phase 4: Execution
 


### PR DESCRIPTION
## Summary

- Defined a structured execution plan approval gate format in SKILL.md between Phase 3.5 and Phase 4
- Gate uses progressive disclosure (orientation, task list, advisories, reference) with a two-field delta model (CHANGE/WHY) for advisories
- Added TASK/CHANGE fields to ADVISE verdict format in AGENT.md so reviewers produce structured data for the gate
- Updated communication protocol to distinguish plan gate (SHOW advisories) from mid-execution (fold silently)
- Documented plan gate vs mid-execution gate distinction in docs/orchestration.md

## Original Prompt

> Improve execution plan approval gate clarity
>
> **Outcome**: The execution plan approval gate shows the full execution plan and provides enough context for each incorporated advisory that the user can make an informed approve/reject decision without hunting through session history. Currently the gate is opaque — it omits the plan and lists advisory summaries that are meaningless without their original context.

## Test plan

- [ ] Run a `/nefario` orchestration and verify the plan approval gate displays task list, advisories (CHANGE/WHY), risks, and review summary
- [ ] Verify "Request changes" workflow loops back to revised gate presentation
- [ ] Verify advisory domain attribution (e.g., `[testing]`) not agent attribution (e.g., `test-minion`)
- [ ] Verify mid-execution gates are unchanged (still use decision brief format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)