### PR TITLE
Decision 29: Reject DESPICABLE.md, adopt CLAUDE.md section convention

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -379,6 +379,21 @@ These decisions were made during the nefario v2.0 update, extending orchestratio
 
 ---
 
+## Configuration (Decision 29)
+
+### Decision 29: Reject DESPICABLE.md, Adopt CLAUDE.md Section Convention
+
+| Field | Value |
+|-------|-------|
+| **Status** | Decided |
+| **Date** | 2026-02-12 |
+| **Choice** | Do not introduce DESPICABLE.md or DESPICABLE.local.md. Consuming projects configure despicable-agents behavior via a `## Despicable Agents` section in their existing CLAUDE.md (public) and CLAUDE.local.md (private). Nefario reads this section via Claude Code's automatic CLAUDE.md loading -- no new discovery logic required. Re-evaluate when 2+ consuming projects demonstrate configuration needs that CLAUDE.md sections cannot serve, or when Claude Code adopts AGENTS.md support (whichever comes first). |
+| **Alternatives rejected** | (1) **Dedicated DESPICABLE.md + DESPICABLE.local.md files** for framework-specific config. Rejected because: zero consuming projects exist to demonstrate need (YAGNI); contradicts Decisions 26 (.nefario.yml rejected) and 27 (overlay removal) made within the same week; requires explicit Read calls in agents since Claude Code does not auto-load custom files; creates precedence complexity (4-file hierarchy); industry consolidating toward fewer config files (AGENTS.md standard). (2) **Status quo with no guidance**. Rejected because consuming projects would rediscover configuration patterns inconsistently. |
+| **Rationale** | 4 of 5 consulted specialists recommended against DESPICABLE.md. Key factors: CLAUDE.md is auto-loaded by Claude Code (zero infrastructure); the configuration surface is small (few preferences, not a plugin architecture); Decision 5 establishes CLAUDE.md as the canonical project customization surface; the ecosystem is consolidating config files, not proliferating them. The dissenting view (software-docs-minion) valued separation of concerns, but the configuration volume does not justify a dedicated file -- the analogy is Prettier (section in package.json) not ESLint (dedicated file). Lucy additionally identified that any configuration mechanism must protect ALWAYS reviewers (security-minion, test-minion, lucy, margo) from exclusion -- this constraint applies regardless of config surface and should be enforced in nefario. |
+| **Consequences** | Consuming projects add a `## Despicable Agents` section to CLAUDE.md for framework preferences. CLAUDE.local.md handles private/local overrides. No new files, discovery logic, or precedence rules needed. Future documentation should include examples of the section convention when external adoption occurs. ALWAYS reviewer protection should be enforced in nefario (separate future task). If AGENTS.md support arrives in Claude Code, the section convention migrates trivially. |
+
+---
+
 ## Deferred
 
 - Nefario-gated complexity classification -- revisit after 20+ full-process runs.

--- a/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config.md
+++ b/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config.md
@@ -1,0 +1,268 @@
+---
+type: nefario-report
+version: 3
+date: "2026-02-12"
+time: "09:26:51"
+task: "Evaluate DESPICABLE.md as project-local configuration for the framework"
+mode: plan
+agents-involved: [nefario, gru, lucy, margo, devx-minion, software-docs-minion, security-minion, test-minion, ux-strategy-minion]
+task-count: 0
+gate-count: 0
+outcome: completed
+---
+
+# Evaluate DESPICABLE.md as Project-Local Configuration
+
+## Summary
+
+The team evaluated whether consuming projects should have dedicated DESPICABLE.md and DESPICABLE.local.md files for framework-specific configuration. Five specialists were consulted (gru, lucy, margo, devx-minion, software-docs-minion) and six mandatory reviewers validated the synthesis. The unanimous recommendation from 4 of 5 specialists is to **reject DESPICABLE.md** and use a `## Despicable Agents` section in the existing CLAUDE.md instead. One specialist (software-docs-minion) dissented, favoring dedicated files for separation-of-concerns reasons.
+
+## Original Prompt
+
+> Evaluate DESPICABLE.md as project-local configuration for the framework
+>
+> **Outcome**: The team reaches a well-reasoned decision on whether consuming projects should have dedicated DESPICABLE.md and DESPICABLE.local.md files for framework-specific configuration, so that project instructions for despicable-agents stay separated from general CLAUDE.md concerns without requiring users to modify files owned by other tools.
+>
+> **Success criteria**:
+> - Clear recommendation (adopt, defer, or reject) with rationale
+> - Precedence rules documented if adopted (DESPICABLE.md vs CLAUDE.md conflicts)
+> - At least gru, lucy, margo, and devx-minion consulted
+> - YAGNI analysis: real demand vs speculative need
+> - Alternative approaches evaluated (e.g., a `## Despicable Agents` section in CLAUDE.md)
+>
+> **Scope**:
+> - In: File naming convention, .md vs .local.md split, interaction with existing CLAUDE.md/CLAUDE.local.md, discoverability for adopters, what configuration options these files would support (agent exclusion, domain spin, orchestration overrides)
+> - Out: Implementation of file parsing, changes to agent runtime, changes to nefario orchestration code
+>
+> **Constraints**:
+> - Consultation only -- produce a decision document, not code
+> - Must include input from gru, lucy, margo, and devx-minion at minimum
+
+## Key Design Decisions
+
+#### Reject DESPICABLE.md, Recommend CLAUDE.md Section Convention
+
+**Rationale**:
+- Zero consuming projects exist outside the toolkit itself -- building per-project config infrastructure now is a YAGNI violation
+- CLAUDE.md is auto-loaded by Claude Code; DESPICABLE.md would require explicit Read calls in 27 agents
+- The industry is consolidating config surfaces (AGENTS.md standard, ESLint flat config), not proliferating them
+- All three proposed config use cases (agent exclusion, domain spin, orchestration overrides) already work via CLAUDE.md sections
+- Decisions 26 (.nefario.yml rejected) and 27 (overlay mechanism removed) established direct precedent within the past week
+
+**Alternatives Rejected**:
+- DESPICABLE.md + DESPICABLE.local.md: Rejected for zero demonstrated demand, 7 complexity points vs. 0 for CLAUDE.md sections, fragile discovery, precedence complexity (4-file hierarchy), and contradiction with freshly-established project principles
+- Status quo (no guidance): Rejected because consuming projects would rediscover configuration patterns inconsistently
+
+### Conflict Resolutions
+
+software-docs-minion recommended adopting DESPICABLE.md on separation-of-concerns grounds. This was the only dissenting view (4-to-1 against). The dissent was acknowledged as valid in principle but assessed as disproportionate: the configuration surface is closer to Prettier (few preferences, fits in a host file section) than ESLint (complex plugin architecture needing its own file). software-docs-minion's own documentation burden estimate (1200-1500 lines for dedicated file vs. 400-600 for CLAUDE.md section) itself demonstrated the overhead differential.
+
+## Phases
+
+### Phase 1: Meta-Plan
+
+Nefario identified 5 specialists to consult: the 4 user-specified agents (gru, lucy, margo, devx-minion) plus software-docs-minion for documentation impact assessment. Key tensions identified upfront: Decision 5 establishes CLAUDE.md as the canonical customization surface, the external skill integration already uses CLAUDE.md precedence (Decision 28), and YAGNI/KISS principles from the Helix Manifesto apply strongly.
+
+### Phase 2: Specialist Planning
+
+Five specialists contributed in parallel. Four reached the same conclusion independently (reject DESPICABLE.md), while one (software-docs-minion) recommended adoption. Key findings per specialist are detailed in the Agent Contributions section below.
+
+### Phase 3: Synthesis
+
+Nefario synthesized the 4-to-1 consensus into a single-task execution plan: write Decision 29 in docs/decisions.md. The conflict resolution weighed the majority's YAGNI/platform-integration/industry-direction arguments against the minority's separation-of-concerns argument and found the majority position more compelling given zero external consumers.
+
+### Phase 3.5: Architecture Review
+
+Six mandatory reviewers evaluated the synthesis. All approved or advised (no blocks). Security-minion and software-docs-minion provided advisory notes that were incorporated into the plan's consequences.
+
+### Phase 4: Execution
+
+Skipped. The user requested a consultation report only, not a decision entry in docs/decisions.md.
+
+### Phase 5: Code Review
+
+Skipped (no code produced).
+
+### Phase 6: Test Execution
+
+Skipped (no tests applicable).
+
+### Phase 7: Deployment
+
+Skipped (not requested).
+
+### Phase 8: Documentation
+
+Skipped (consultation only).
+
+<details>
+<summary>Agent Contributions (5 planning, 6 review)</summary>
+
+### Planning
+
+**gru**: HOLD on DESPICABLE.md. The industry is consolidating config surfaces -- AGENTS.md (Linux Foundation / AAIF, 40,000+ repo adoption) is emerging as the cross-platform standard. Frameworks that ship their own config files (LangGraph, CrewAI) do so because they are application frameworks with structured, machine-parsed configuration, not guidance files for coding agents. Despicable-agents config is closer to Prettier (section-in-host-file) than ESLint (dedicated file). Key risk: AGENTS.md collision when Claude Code adopts it (71% probability in 2026).
+- Adopted: CLAUDE.md section convention as recommended alternative; AGENTS.md migration note as future consideration
+- Risks flagged: Config fragmentation (3+ files), discovery failure (27 agents need explicit Read), AGENTS.md collision
+
+**lucy**: BLOCK on DESPICABLE.md. Dual-file validation creates multiplicative compliance complexity (N x M directive pairs). Convention fragmentation violates Decision 5. All three use cases already work via CLAUDE.md. Critical security finding: any configuration allowing exclusion of ALWAYS reviewers (security-minion, test-minion, lucy, margo) undermines Decision 10's safety guarantee -- this applies regardless of config surface and needs enforcement in nefario.
+- Adopted: ALWAYS reviewer protection concern carried into consequences; single-surface recommendation
+- Risks flagged: Convention fragmentation, security blind spots, precedence complexity (4 new questions)
+
+**margo**: BLOCK on DESPICABLE.md. Fails every YAGNI test. Zero consuming projects, zero user requests. Decision 27 (overlay removal, 3 days ago) and Decision 26 (.nefario.yml rejection, 2 days ago) set direct precedent. Complexity cost: 7 points for DESPICABLE.md vs. 0 for CLAUDE.md sections.
+- Adopted: "Not now" framing with explicit re-introduction trigger; complexity cost analysis methodology
+- Risks flagged: Building infrastructure nobody asked for; contradicting freshly-established precedent
+
+**devx-minion**: Reject DESPICABLE.md. CLAUDE.md section is more discoverable (developers already know CLAUDE.md), more maintainable (one file vs. two), lower cognitive overhead (no new concept to learn). None of the proposed config options justify a new file -- agent exclusion has low utility (nefario already selects by relevance), domain spin already works via CLAUDE.md, orchestration overrides are dangerous (would bypass governance). ESLint ecosystem moved toward consolidation, not proliferation.
+- Adopted: Realistic utility assessment of each config option; discovery-at-planning-time-only recommendation
+- Risks flagged: Scope creep into config infrastructure; precedence complexity; onboarding friction
+
+**software-docs-minion** (DISSENT): Adopt DESPICABLE.md. Separation of concerns wins -- framework config separate from general CLAUDE.md. Better discoverability (new contributors see the file), better reusability (copy across projects), cleaner git history. Documentation burden is modest (1200-1500 lines). Proposed 7 documentation tasks.
+- Adopted: Documentation burden estimate used as evidence for overhead differential; acknowledgment that consuming-projects guidance is a future need
+- Risks flagged: Configuration sprawl, precedence confusion
+
+### Architecture Review
+
+**security-minion**: ADVISE. ALWAYS reviewer bypass risk is an open gap -- CLAUDE.local.md can exclude mandatory reviewers with no enforcement. Recommend tagging as security debt. Also note that unstructured LLM interpretation of config means no formal validation.
+
+**test-minion**: APPROVE. No testing concerns for a decision document task.
+
+**ux-strategy-minion**: APPROVE. CLAUDE.md section optimizes for simplicity and cognitive load reduction. Zero discovery friction, satisficing-friendly (one canonical place), matches existing mental model. Re-introduction trigger is well-calibrated.
+
+**software-docs-minion**: ADVISE. Decision 29 alone does not teach consuming projects how to use CLAUDE.md sections. Recommend a consuming-projects guide as future documentation when external adoption occurs. Format consistency verified against existing decisions.md conventions.
+
+**lucy**: APPROVE. All success criteria covered. Dissenting view given fair treatment. Scope containment verified -- no creep beyond consultation.
+
+**margo**: APPROVE. Appropriately minimal scope. Zero complexity addition. Decision itself is YAGNI-aligned.
+
+</details>
+
+## Execution
+
+### Tasks
+
+| # | Task | Agent | Status |
+|---|------|-------|--------|
+| - | No execution tasks | - | User requested report only |
+
+### Files Changed
+
+| File Path | Action | Description |
+|-----------|--------|-------------|
+| docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config.md | created | This consultation report |
+| docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/ | created | Companion directory with working files |
+
+## Verification
+
+| Phase | Result |
+|-------|--------|
+| Code Review | Skipped (no code produced) |
+| Test Execution | Skipped (no tests applicable) |
+| Deployment | Skipped (not requested) |
+| Documentation | Skipped (consultation only) |
+
+<details>
+<summary>Working Files (10 files)</summary>
+
+Companion directory: [2026-02-12-092651-evaluate-despicable-md-config/](./2026-02-12-092651-evaluate-despicable-md-config/)
+
+- [Original Prompt](./2026-02-12-092651-evaluate-despicable-md-config/prompt.md)
+- [Phase 1: Meta-plan](./2026-02-12-092651-evaluate-despicable-md-config/phase1-metaplan.md)
+- [Phase 2: gru](./2026-02-12-092651-evaluate-despicable-md-config/phase2-gru.md)
+- [Phase 2: lucy](./2026-02-12-092651-evaluate-despicable-md-config/phase2-lucy.md)
+- [Phase 2: margo](./2026-02-12-092651-evaluate-despicable-md-config/phase2-margo.md)
+- [Phase 2: devx-minion](./2026-02-12-092651-evaluate-despicable-md-config/phase2-devx-minion.md)
+- [Phase 2: software-docs-minion](./2026-02-12-092651-evaluate-despicable-md-config/phase2-software-docs-minion.md)
+- [Phase 3: Synthesis](./2026-02-12-092651-evaluate-despicable-md-config/phase3-synthesis.md)
+- [Phase 3.5: security-minion](./2026-02-12-092651-evaluate-despicable-md-config/phase3.5-security-minion.md)
+- [Phase 3.5: software-docs-minion](./2026-02-12-092651-evaluate-despicable-md-config/phase3.5-software-docs-minion.md)
+
+</details>
+
+## Consultation Findings
+
+### The Question
+
+Should consuming projects have dedicated DESPICABLE.md and DESPICABLE.local.md files for framework-specific configuration of despicable-agents?
+
+### Recommendation: Reject (with re-introduction trigger)
+
+**Do not introduce DESPICABLE.md or DESPICABLE.local.md.** Consuming projects should configure despicable-agents behavior via a `## Despicable Agents` section in their existing CLAUDE.md (public) and CLAUDE.local.md (private).
+
+**Re-introduction trigger**: Revisit when 2+ consuming projects demonstrate configuration needs that CLAUDE.md sections cannot serve, OR when Claude Code adopts AGENTS.md support (whichever comes first).
+
+### Arguments For Rejection (4 specialists)
+
+| Argument | Source | Strength |
+|----------|--------|----------|
+| Zero consuming projects -- no demonstrated demand | margo | Decisive |
+| Decisions 26 + 27 set direct YAGNI precedent this week | margo | Strong |
+| CLAUDE.md auto-loaded; DESPICABLE.md needs explicit discovery | gru, devx-minion | Strong |
+| Industry consolidating config (AGENTS.md standard) | gru | Strong |
+| All 3 config use cases already work via CLAUDE.md | lucy, devx-minion | Strong |
+| Convention fragmentation -- no crisp boundary between files | lucy | Strong |
+| 7 complexity points vs. 0 for CLAUDE.md sections | margo | Strong |
+| Config options either have low utility or are dangerous | devx-minion | Moderate |
+
+### Arguments For Adoption (1 specialist)
+
+| Argument | Source | Strength |
+|----------|--------|----------|
+| Separation of concerns -- framework config separate from general | software-docs-minion | Moderate |
+| Better discoverability -- file is visible in project root | software-docs-minion | Moderate |
+| Better reusability -- copy across projects without extraction | software-docs-minion | Weak |
+| Cleaner git history -- framework changes isolated | software-docs-minion | Weak |
+| Progressive disclosure -- learn CLAUDE.md first, then DESPICABLE.md | software-docs-minion | Weak |
+
+### Why the Dissent Did Not Prevail
+
+The separation-of-concerns argument is valid in principle but disproportionate for the current configuration surface:
+
+1. **Volume mismatch**: The despicable-agents config is a few preferences (agent exclusions, technology spin, orchestration tweaks) -- not a complex plugin architecture. This is Prettier-scale config (fits in package.json), not ESLint-scale config (needs its own file).
+
+2. **Discovery asymmetry**: DESPICABLE.md is discoverable only if you already know it exists. CLAUDE.md is already the place every developer looks for project-level AI config. A section in a known file beats a new file you must learn about.
+
+3. **Platform advantage**: CLAUDE.md is auto-loaded by Claude Code with zero infrastructure. DESPICABLE.md requires explicit Read calls -- either in all 27 agents (fragile, bloated) or only in nefario (single point of failure). The auto-loading advantage is structural and hard to overcome.
+
+4. **Timing**: The ecosystem is moving toward fewer config files (AGENTS.md consolidation), not more. Introducing a new file now means potential migration twice (DESPICABLE.md -> AGENTS.md) instead of once (CLAUDE.md section -> AGENTS.md section).
+
+### Configuration Options Utility Assessment
+
+| Option | Utility | Recommendation |
+|--------|---------|----------------|
+| Agent exclusion | Low | Nefario already selects by task relevance. A CLAUDE.md note like "backend-only project, no frontend" achieves the same result |
+| Domain spin | Medium | Already works via CLAUDE.md technology preferences. Just document the pattern with examples |
+| Orchestration overrides | Low to Dangerous | Phase 3.5 skip and ALWAYS reviewer exclusion undermine governance. Runtime overrides via user commands already cover legitimate cases |
+| Skill preferences | Already exists | Decision 28 Tier 1 routes through CLAUDE.md already |
+
+### Recommended Alternative: CLAUDE.md Section Convention
+
+```markdown
+## Despicable Agents
+
+### Project Context
+- Backend-only Python API; no frontend or web UI
+- Uses PostgreSQL and Redis; deployed on Kubernetes
+
+### Agent Preferences
+- Prefer security-minion review for all PRs touching auth/
+- Skip sitespeed-minion (no web frontend in this project)
+
+### Orchestration
+- Default mode: PLAN (always require approval before execution)
+- Report directory: docs/reports/
+```
+
+This approach:
+- Is automatically read by Claude Code (zero infrastructure)
+- Is visible to all Claude Code agents (not just despicable-agents)
+- Works today without any code changes
+- Follows the AGENTS.md philosophy ("just Markdown, use any headings")
+- Migrates trivially when AGENTS.md support arrives in Claude Code
+
+### Open Items (Not In Scope of This Consultation)
+
+1. **ALWAYS reviewer protection**: Lucy identified that CLAUDE.md/CLAUDE.local.md can currently instruct exclusion of mandatory Phase 3.5 reviewers with no enforcement. This needs a runtime guardrail in nefario (separate task).
+
+2. **Consuming-projects guide**: When external projects begin adopting the toolkit, a short guide showing how to use CLAUDE.md sections for framework config would be valuable. Not needed until there are actual consumers.
+
+3. **AGENTS.md migration**: When Claude Code adopts AGENTS.md support, the `## Despicable Agents` section convention should be evaluated for migration. The section-based approach migrates trivially.

--- a/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase1-metaplan.md
+++ b/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase1-metaplan.md
@@ -1,0 +1,102 @@
+# Meta-Plan: Evaluate DESPICABLE.md as Project-Local Configuration
+
+## Context
+
+despicable-agents is a globally-installed agent toolkit (27 agents + 2 skills deployed to `~/.claude/`). It operates on any target project from that project's working directory. Currently, all project-specific configuration for despicable-agents lives in the target project's `CLAUDE.md` and `CLAUDE.local.md` -- the same files used for general Claude Code instructions. There is no framework-specific configuration surface.
+
+The proposal under evaluation: introduce `DESPICABLE.md` (checked in) and `DESPICABLE.local.md` (gitignored) as dedicated configuration files for despicable-agents in consuming projects, separating framework concerns from general Claude Code concerns.
+
+**Key design tensions:**
+- CLAUDE.md is already the canonical place for project instructions (Decision 5: "All project customization must flow through CLAUDE.md or CLAUDE.local.md")
+- The external skill integration mechanism (Decision 28) already handles project-local skill precedence via CLAUDE.md declarations
+- Lucy's remit includes CLAUDE.md compliance checking -- a new config file changes what she validates
+- The current architecture states: "Project context belongs in the target project's CLAUDE.md, not in agents"
+- YAGNI/KISS principles from the Helix Manifesto apply strongly to any new configuration surface
+
+## Planning Consultations
+
+### Consultation 1: Technology Landscape Assessment
+
+- **Agent**: gru
+- **Planning question**: From a technology landscape perspective, how do other agent frameworks and AI toolkits handle project-local configuration? Specifically: (1) Do frameworks like LangGraph, CrewAI, AutoGen, or the OpenAI Agents SDK use dedicated config files vs. relying on the host platform's config? (2) Is there an emerging convention for "framework config layered on top of platform config"? (3) What is the risk of inventing a custom config surface (DESPICABLE.md) vs. using the platform's native config (CLAUDE.md sections)?
+- **Context to provide**: The current architecture (agents deployed globally, project context via CLAUDE.md), the external skill integration precedence model (CLAUDE.md > project-local > specificity), Decision 26 (decoupling from self-referential paths).
+- **Why this agent**: Gru evaluates technology decisions against the broader landscape. The question of "dedicated framework config file vs. section in platform config" is a technology strategy decision with precedent in other ecosystems (e.g., `.eslintrc` vs. `package.json` eslint key, `tsconfig.json` vs. nothing).
+
+### Consultation 2: Intent Alignment and Convention Assessment
+
+- **Agent**: lucy
+- **Planning question**: From a governance and convention enforcement perspective: (1) How would DESPICABLE.md interact with CLAUDE.md compliance checking -- does lucy need to validate both files, and what happens when they conflict? (2) Does a separate config file create convention fragmentation (users unsure where to put agent-related instructions)? (3) Is the current approach of using CLAUDE.md sections already sufficient for the configuration use cases identified (agent exclusion, domain spin, orchestration overrides)? (4) What precedence rules would be needed if DESPICABLE.md contradicts CLAUDE.md?
+- **Context to provide**: Lucy's current CLAUDE.md compliance remit, the external skill precedence model, the existing `CLAUDE.local.md` public/private split pattern, the specific config options proposed (agent exclusion, domain spin, orchestration overrides).
+- **Why this agent**: Lucy owns convention enforcement and CLAUDE.md compliance. A new config file directly impacts her domain -- she needs to assess whether it creates governance complexity or simplifies it.
+
+### Consultation 3: YAGNI and Simplicity Assessment
+
+- **Agent**: margo
+- **Planning question**: Apply YAGNI/KISS analysis to the DESPICABLE.md proposal: (1) Is there demonstrated real demand for dedicated framework configuration, or is this speculative? (2) How many consuming projects currently exist, and what configuration do they actually need? (3) Could the identified configuration needs (agent exclusion, domain spin, orchestration overrides) be served by a `## Despicable Agents` section in CLAUDE.md with zero new files? (4) What is the complexity cost of a new config file (discovery logic, precedence rules, documentation, user education) vs. the complexity cost of overloading CLAUDE.md? (5) Apply the "one-agent rule" analog: do not build configuration infrastructure until 2+ consuming projects demonstrate the need.
+- **Context to provide**: Decision 27 (removed overlay mechanism applying the one-agent rule), the Helix Manifesto principles, the current state of consuming projects (if any), the full list of proposed config options.
+- **Why this agent**: Margo is the YAGNI/KISS guardian. The central question is whether this is solving a real problem or a speculative one. Margo's analysis will be the strongest voice on whether to defer.
+
+### Consultation 4: Configuration File Design and Developer Experience
+
+- **Agent**: devx-minion
+- **Planning question**: Evaluate the developer experience of the proposed configuration surface: (1) Compare the DX of `DESPICABLE.md` + `DESPICABLE.local.md` vs. a `## Despicable Agents` section in `CLAUDE.md` -- which is more discoverable, more maintainable, and has lower cognitive overhead for adopters? (2) If a dedicated file is adopted, what should its format be (freeform markdown like CLAUDE.md, structured YAML frontmatter + markdown body, or pure structured data like YAML/TOML)? (3) What configuration options would a consuming project realistically need? Evaluate each proposed option (agent exclusion, domain spin, orchestration overrides) for real-world utility. (4) How should the file be discovered -- by nefario at planning time, by individual agents at runtime, or both? (5) What does the "getting started" experience look like -- does a user need to create this file to use despicable-agents, or is it purely optional? (6) Assess error cases: what happens when the file has invalid content, conflicts with CLAUDE.md, or references agents that do not exist?
+- **Context to provide**: The devx-minion's expertise in configuration file design (formats, defaults, overrides, validation), the existing CLAUDE.md/CLAUDE.local.md split pattern, the external skill integration discovery model (filesystem scanning), Decision 26 (CWD-relative detection).
+- **Why this agent**: devx-minion owns configuration file design, progressive complexity, and developer onboarding. The format, discoverability, and error handling of any new config surface is core DX work.
+
+### Consultation 5: Documentation Impact Assessment
+
+- **Agent**: software-docs-minion
+- **Planning question**: If DESPICABLE.md is adopted, what documentation changes would be needed? Specifically: (1) Which existing docs reference "project context belongs in CLAUDE.md" and would need updating? (2) What new documentation would be needed (configuration reference, getting-started guide for consuming projects, precedence rules)? (3) Does the introduction of a new config file warrant an update to architecture.md? (4) If the recommendation is to use a CLAUDE.md section instead, what documentation is needed for that convention? Assess the documentation burden of each approach (dedicated file vs. CLAUDE.md section vs. status quo).
+- **Context to provide**: The current documentation structure (architecture.md hub, external-skills.md, deployment.md, using-nefario.md), the "Generic domain specialists" design principle, Decision 5 (user-scope memory, project customization via CLAUDE.md).
+- **Why this agent**: software-docs-minion assesses documentation impact of architectural decisions. The documentation burden is a real cost that factors into the adopt/defer/reject decision.
+
+## Cross-Cutting Checklist
+
+- **Testing**: Not applicable. This is a consultation producing a decision document, not code or configuration. No executable output to test.
+- **Security**: Not applicable to the consultation itself. However, security-minion input would be relevant if DESPICABLE.md could contain instructions that override security-related agent behavior (e.g., excluding security-minion from reviews). **Include a security question as a sub-question in lucy's consultation** rather than a standalone consultation: "Can DESPICABLE.md configuration create security blind spots (e.g., by excluding security-minion or overriding review requirements)?"
+- **Usability -- Strategy**: Covered by devx-minion (Consultation 4) and margo (Consultation 3). The UX strategy dimension is the DX question here -- devx-minion's configuration file design expertise is more precisely relevant than ux-strategy-minion's journey mapping for this tool-configuration task. **Not included as separate consultation** because the task has no end-user interface; the "users" are developers configuring a CLI toolkit.
+- **Usability -- Design**: Not applicable. No user-facing interface is produced.
+- **Documentation**: Included as Consultation 5 (software-docs-minion).
+- **Observability**: Not applicable. No runtime components.
+
+## Anticipated Approval Gates
+
+**Zero approval gates for the consultation itself.** The output is a decision document (ADR-style), not an execution plan with dependent tasks. The decision document will be presented to the user as the final deliverable for their judgment (adopt/defer/reject).
+
+If the recommendation is "adopt," a follow-up implementation plan would go through the normal nefario process with its own gates. That plan is out of scope for this consultation.
+
+## Rationale
+
+**Five consultations selected** (gru, lucy, margo, devx-minion, software-docs-minion). The four user-specified agents are included. software-docs-minion is added because the documentation impact is a material factor in the decision.
+
+**Agents not included and why:**
+- **ux-strategy-minion**: The "users" here are developers configuring a CLI toolkit. devx-minion covers this DX concern more precisely. ux-strategy-minion's journey mapping and cognitive load analysis are less relevant for a config-file decision than devx-minion's configuration file design expertise.
+- **security-minion**: Security concern (can config override security reviews?) is addressed as a sub-question in lucy's consultation rather than a full standalone consultation. The risk surface is narrow and well-bounded.
+- **test-minion**: No executable output to test.
+- **All other minions**: Not relevant to a configuration convention decision.
+
+**Why not fewer?** Margo and devx-minion address overlapping concerns (simplicity vs. DX) but from different angles -- margo evaluates "should we build this at all?" while devx-minion evaluates "if we build it, what should it look like?" Both perspectives are needed for a well-reasoned recommendation.
+
+## Scope
+
+**In scope:**
+- File naming convention (DESPICABLE.md, .despicable.yml, or alternatives)
+- Public/private split (.md vs .local.md)
+- Interaction with existing CLAUDE.md/CLAUDE.local.md
+- Discoverability for adopters (how do they learn about it?)
+- Configuration options these files would support (agent exclusion, domain spin, orchestration overrides)
+- Comparison with alternative approaches (CLAUDE.md section, status quo)
+- Precedence rules if adopted (DESPICABLE.md vs CLAUDE.md conflicts)
+- YAGNI analysis: real demand vs speculative need
+
+**Out of scope:**
+- Implementation of file parsing or discovery logic
+- Changes to agent runtime or AGENT.md files
+- Changes to nefario orchestration code
+- Changes to the-plan.md
+
+**Deliverable:** A decision document in ADR format with a clear recommendation (adopt, defer, or reject), rationale, and precedence rules (if adopt).
+
+## External Skill Integration
+
+No external skills detected in project that are relevant to this consultation task. The two project-local skills (despicable-lab, despicable-prompter) are agent build/coaching tools, not relevant to a configuration convention decision.

--- a/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase2-devx-minion.md
+++ b/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase2-devx-minion.md
@@ -1,0 +1,116 @@
+## Domain Plan Contribution: devx-minion
+
+### Recommendations
+
+#### 1. Dedicated File vs. CLAUDE.md Section: CLAUDE.md Section Wins
+
+After evaluating both approaches against DX fundamentals, I strongly recommend **against** introducing `DESPICABLE.md` / `DESPICABLE.local.md` as dedicated files. A `## Despicable Agents` section within the existing `CLAUDE.md` / `CLAUDE.local.md` is the better choice. Here is the analysis across three dimensions:
+
+**Discoverability**: `CLAUDE.md` is already the canonical place developers look for project-level AI configuration. Every Claude Code user knows this file. A `DESPICABLE.md` file is invisible until someone tells you it exists. There is no `claude --help` output, no Claude Code documentation, and no IDE integration that would surface `DESPICABLE.md` as meaningful. A section in `CLAUDE.md` is discovered by anyone reading the file they already know about. The existing external skill precedence system (Decision 28, Tier 1) already routes through `CLAUDE.md` -- splitting configuration across two files means developers must check two places to understand routing behavior.
+
+**Maintainability**: One file to maintain vs. two. A dedicated file introduces a new file lifecycle (creation, updates, git tracking, `.local.md` variant gitignoring). Every project that adopts despicable-agents adds two potential files to manage. The CLAUDE.md section approach means zero new files -- configuration lives where it already belongs. Drift between CLAUDE.md and DESPICABLE.md is a real risk: what happens when CLAUDE.md says "prefer vanilla JS" but DESPICABLE.md tells the frontend-minion to use React? Precedence rules create hidden complexity.
+
+**Cognitive overhead**: Tool proliferation is the enemy of developer experience. Every new config file is a concept a developer must learn, remember, and maintain. The `.eslintrc` vs. `package.json` eslint key comparison is instructive: the ecosystem moved TOWARD consolidation (`eslint.config.js` flat config), not away from it. `tsconfig.json` exists because TypeScript genuinely needs its own file -- the configuration surface is enormous. Despicable-agents configuration is small enough (a few preferences, maybe agent exclusions) to fit comfortably in a CLAUDE.md section.
+
+The Helix Manifesto principle applies: "YAGNI -- don't build it until you need it." No consuming project has yet expressed a need for more configuration surface than CLAUDE.md provides. Decision 26 already rejected a `.nefario.yml` config file as YAGNI.
+
+#### 2. If a Dedicated File Is Adopted Anyway: Freeform Markdown
+
+If the team overrides my recommendation and introduces a dedicated file, the format should be **freeform markdown** (same as CLAUDE.md), not YAML frontmatter + body or pure structured data.
+
+Rationale:
+- **Consistency**: CLAUDE.md and CLAUDE.local.md are freeform markdown. A third config file in a different format breaks the mental model.
+- **LLM-native**: Claude reads and reasons about markdown natively. Structured YAML/TOML requires parsing logic in agent prompts -- and if nefario or individual agents must parse it, that is prompt bloat for the one agent (nefario) that reads this file.
+- **Low barrier**: A developer can start with `## Agent Preferences\n\nSkip seo-minion for this project.` and it works. No schema to learn, no validation to pass.
+- **Flexible**: Freeform text handles both well-known preferences ("exclude X") and emergent ones ("prefer monorepo patterns for all infrastructure") without schema changes.
+
+The only case for structured data would be if tooling (not LLMs) needs to parse the file programmatically. There is no such tooling in the current architecture, and building it would be speculative.
+
+#### 3. Configuration Options: Realistic Utility Assessment
+
+**Agent exclusion** (e.g., "skip seo-minion for this project"):
+- Utility: **LOW**. The current system already handles this implicitly -- nefario's meta-plan only consults agents relevant to the task. A project that never touches SEO never invokes seo-minion. Explicit exclusion is only needed when nefario consistently misjudges relevance, which is a bug to fix in nefario, not a config to work around. Edge case: a backend-only project where nefario still recommends frontend-minion review. Even then, Phase 3.5 conditional reviewer logic already gates on task type.
+- Recommendation: **Do not implement**. If needed, a one-line note in CLAUDE.md suffices: "This is a backend API project; no frontend or web UI work."
+
+**Domain spin** (e.g., "this project uses Kubernetes heavily, emphasize edge-minion"):
+- Utility: **MEDIUM**. This is essentially what CLAUDE.local.md already does in the despicable-agents project itself (technology bias preferences). Any project can add `## Technology Preferences` to CLAUDE.md today and agents will read it. A dedicated mechanism adds no value over what already works.
+- Recommendation: **Document the pattern** rather than building a mechanism. Show examples of how CLAUDE.md sections influence agent behavior.
+
+**Orchestration overrides** (e.g., "skip Phase 3.5 for this project", "max 2 gates"):
+- Utility: **LOW to DANGEROUS**. Phase 3.5 is non-skippable by design (Decision 15). Gate budgets are already calibrated. Allowing per-project orchestration overrides undermines the governance model. If a project can disable security review, the security guarantee is worthless. The user can already override at runtime (`MODE: PLAN`, explicit skip requests).
+- Recommendation: **Do not implement**. Orchestration parameters belong in the skill, not in per-project config. Runtime overrides via user commands already cover legitimate use cases.
+
+**Default reviewers / always-skip reviewers**:
+- Utility: **VERY LOW**. Conditional reviewers are already gated by task type. Forcing a reviewer on or off for an entire project is too coarse -- it should be per-task, which is already handled by nefario's reviewer selection logic.
+- Recommendation: **Do not implement**.
+
+**Skill preferences** (e.g., "Always use .skills/deploy for deployment"):
+- Utility: **ALREADY EXISTS**. This is Precedence Tier 1 in the external skill integration system (Decision 28). It already reads from CLAUDE.md. No new mechanism needed.
+- Recommendation: **Already done**. Just document it.
+
+Net assessment: **None of the proposed configuration options justify a new file.** Everything either already works via CLAUDE.md, or should not be configurable.
+
+#### 4. Discovery Mechanism: Nefario at Planning Time Only
+
+If any file-based configuration is adopted, it should be discovered by **nefario at Phase 1 (meta-plan) only**, not by individual agents at runtime.
+
+Rationale:
+- **Single reader**: Only one agent (nefario) needs to understand project-level orchestration preferences. Individual minions receive their instructions through task prompts that nefario constructs.
+- **Context efficiency**: Reading a config file in 27 agents wastes 27x the context for information that should be absorbed once and distributed through task prompts.
+- **Consistency**: If each agent independently reads the config, they may interpret it differently. Nefario as the single interpreter ensures consistent application.
+- **Already the pattern**: Nefario already reads CLAUDE.md during meta-planning for external skill preferences. Extending this to read a section of CLAUDE.md is zero additional discovery logic.
+
+#### 5. Getting Started Experience: Purely Optional, Zero-Config Default
+
+The "getting started" experience must be: install (`./install.sh`), use (`/nefario <task>`). No file creation required.
+
+This aligns with the zero-config principle: 80% of users should never need to change configuration. The existing CLAUDE.md (which every Claude Code project already has or quickly creates) is sufficient. If a user wants to influence agent behavior, they add a section to their existing CLAUDE.md. No new file, no new concept, no new documentation page to read.
+
+Time to first success should not increase by even one step. The current TTFS for despicable-agents is already good (install + invoke). Adding a "create DESPICABLE.md" step would be a regression.
+
+#### 6. Error Cases Assessment
+
+If CLAUDE.md section approach is used (recommended):
+- **Invalid content**: Not possible in the traditional sense -- it is freeform markdown interpreted by an LLM. "Invalid" means "unclear", which the LLM handles gracefully by ignoring or asking for clarification. No parsing errors, no startup validation needed.
+- **Conflicts with CLAUDE.md**: Cannot conflict because it IS CLAUDE.md. The section is part of the same document.
+- **References to nonexistent agents**: Nefario already resolves agent names against its delegation table. An unknown agent name in a CLAUDE.md preference is handled the same way as an unknown agent name in any other context -- nefario ignores it or maps to the closest match. No special error handling needed.
+
+If dedicated DESPICABLE.md were adopted (not recommended):
+- **Invalid content**: With freeform markdown, same as above. With structured YAML, you need schema validation, error messages, and a validation step. This is build complexity for marginal value.
+- **Conflicts with CLAUDE.md**: This is the dangerous case. CLAUDE.md says "vanilla JS", DESPICABLE.md says "use React for frontend-minion." Precedence must be defined and documented. Users must understand which file wins. This is exactly the cognitive overhead that makes dedicated files worse.
+- **Missing file**: Must be optional. Must not produce warnings or errors. Must not degrade behavior.
+- **References to nonexistent agents**: Must fail gracefully. Error message should list valid agent names. Must not crash nefario or block orchestration.
+
+### Proposed Tasks
+
+**Task 1: Document the CLAUDE.md configuration pattern**
+- What: Write a section in the user-facing documentation (e.g., `docs/using-nefario.md` or a new `docs/project-configuration.md`) showing how consuming projects can influence despicable-agents behavior through CLAUDE.md sections.
+- Deliverables: Documentation with 3-4 examples (technology preferences, skill routing, project context for agent selection).
+- Dependencies: None.
+
+**Task 2: Add example CLAUDE.md sections to getting-started documentation**
+- What: Show concrete examples in quickstart/onboarding docs: "If your project is backend-only, add this to CLAUDE.md: ..." and "If you prefer certain technologies, add this: ..."
+- Deliverables: 4-6 example snippets integrated into existing docs.
+- Dependencies: Task 1.
+
+**Task 3: Validate that nefario already reads CLAUDE.md preferences correctly**
+- What: Confirm that nefario's Phase 1 meta-plan step already reads and applies CLAUDE.md preferences for skill routing and project context. If gaps exist, document them.
+- Deliverables: Verification report; any gaps logged as issues.
+- Dependencies: None.
+
+### Risks and Concerns
+
+1. **Scope creep into configuration infrastructure**: The biggest risk is that evaluating configuration surface leads to building configuration infrastructure. Decision 26 explicitly rejected `.nefario.yml` as YAGNI. The same principle applies here. The existing CLAUDE.md pattern covers all realistic needs. Building a new file format, discovery mechanism, validation layer, and error handling for it would violate YAGNI, KISS, and Lean-and-Mean simultaneously.
+
+2. **Precedence complexity**: Introducing a second configuration file immediately creates precedence questions. CLAUDE.md says X, DESPICABLE.md says Y -- which wins? This is the same problem that plagued the `package.json` vs `.eslintrc` split in the ESLint ecosystem, which they ultimately resolved by moving toward a single flat config file.
+
+3. **Onboarding friction**: Every new file a project must know about increases the learning curve. despicable-agents is a globally-installed toolkit -- it should feel invisible, not demand project-level setup. The best developer tool is the one nobody notices because it just works.
+
+4. **Documentation debt**: A dedicated file requires its own documentation: what it does, how to create it, what options exist, how it interacts with CLAUDE.md, the .local.md variant for private settings, error handling. This is documentation that does not need to exist if the answer is "put it in CLAUDE.md."
+
+### Additional Agents Needed
+
+- **software-docs-minion**: Should review whatever documentation approach is chosen to ensure it integrates with existing docs structure and maintains consistent style. Already likely involved in the planning phase.
+- **margo**: Should validate that the chosen approach satisfies YAGNI/KISS. Given that my recommendation is "do not build this," margo's assessment is particularly relevant as a second opinion on whether the complexity is justified.
+
+No other additional agents are needed. This is primarily a DX design decision, not a multi-domain technical problem.

--- a/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase2-gru.md
+++ b/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase2-gru.md
@@ -1,0 +1,215 @@
+## Domain Plan Contribution: gru
+
+### Ring Classification: HOLD
+
+Do not introduce DESPICABLE.md / DESPICABLE.local.md at this time. The pattern
+is counter to the emerging industry convergence on fewer config files, and
+the problem it solves has lighter-weight alternatives that carry less
+ecosystem risk. Re-evaluate in 6 months (August 2026) when AGENTS.md support
+in Claude Code may change the entire config surface.
+
+---
+
+### Recommendations
+
+#### 1. How Other Agent Frameworks Handle Project-Local Configuration
+
+| Framework | Config Mechanism | File Type | Layered? |
+|-----------|-----------------|-----------|----------|
+| **LangGraph** | `langgraph.json` in project root | Dedicated JSON file | No (single file) |
+| **CrewAI** | `config/agents.yaml` + `config/tasks.yaml` | Dedicated YAML files | No (convention dirs) |
+| **AutoGen/AG2** | `OAI_CONFIG_LIST` env var or JSON file | Env + JSON | No |
+| **OpenAI Agents SDK** | Programmatic (Python/TS code) | No config file | N/A |
+| **AGENTS.md (Codex, Cursor, Jules, etc.)** | Markdown file(s) in repo | Platform-agnostic Markdown | Yes (directory tree) |
+| **Claude Code** | `CLAUDE.md` / `CLAUDE.local.md` | Platform-specific Markdown | Yes (directory tree + global) |
+| **Cursor** | `.cursor/rules/*.mdc` + AGENTS.md | Both dedicated and shared | Yes (glob + frontmatter) |
+
+**Key finding**: The industry is consolidating, not fragmenting. AGENTS.md
+(now under Linux Foundation / AAIF, adopted by 40,000+ repos) is emerging as
+the single cross-platform config surface. Teams previously maintained 4-6
+overlapping files (.cursorrules, CLAUDE.md, .gemini, copilot-instructions.md)
+and the explicit purpose of AGENTS.md is to eliminate this duplication.
+Introducing DESPICABLE.md would swim against this tide.
+
+Frameworks that ship their own config files (LangGraph, CrewAI) do so because
+they are **application frameworks** that need structured, machine-parsed
+configuration (dependency graphs, agent definitions, task routing). They are
+not guidance files for coding agents -- they are build manifests. This is the
+crucial distinction: despicable-agents delivers guidance through system prompts
+loaded by Claude Code, not through a separate runtime that parses config files.
+
+#### 2. Is There an Emerging Convention for "Framework Config on Top of Platform Config"?
+
+Yes, but the convention is **sections within the platform file, not separate
+files**. Evidence:
+
+- **AGENTS.md spec** explicitly supports freeform Markdown sections. The
+  expected pattern is: add a section header for your framework's concerns.
+  The spec says "use any headings you like."
+- **Codex layering model**: `~/.codex/AGENTS.md` (global) -> repo root
+  AGENTS.md -> subdirectory AGENTS.md, with closer files taking precedence.
+  This is exactly how CLAUDE.md already works.
+- **Cursor** evolved from a dedicated `.cursorrules` file to `.cursor/rules/`
+  directory to now also supporting AGENTS.md. The trajectory is toward
+  consolidation, not proliferation.
+- **package.json precedent**: The JavaScript ecosystem tried both patterns
+  (`.eslintrc` dedicated file vs. `"eslintConfig"` key in package.json). The
+  dedicated file won for ESLint -- but ESLint is a complex tool with its own
+  inheritance model, plugin system, and parser configuration. Simple guidance
+  (like Prettier's few options) works fine as a section in package.json.
+
+Despicable-agents config is closer to Prettier (a few behavioral preferences)
+than ESLint (a complex plugin architecture). Section-in-host-file is the right
+pattern for this complexity level.
+
+#### 3. Risk Analysis: Custom Config Surface (DESPICABLE.md) vs. Platform Native (CLAUDE.md Sections)
+
+**Risks of introducing DESPICABLE.md:**
+
+| Risk | Severity | Detail |
+|------|----------|--------|
+| **Config fragmentation** | High | Users must now maintain 3 files (CLAUDE.md, CLAUDE.local.md, DESPICABLE.md) plus potentially AGENTS.md when Claude Code adds support. Each file must be understood, versioned, and kept coherent. |
+| **Discovery failure** | High | Claude Code reads CLAUDE.md automatically. A DESPICABLE.md requires explicit reading logic -- either in every agent's system prompt (27 agents) or in SKILL.md (fragile if invoked outside nefario). If the file is not read, configuration is silently ignored. |
+| **AGENTS.md collision** | Medium | Claude Code will likely adopt AGENTS.md support (71% prediction market probability in 2026). When it does, the layering model changes. DESPICABLE.md becomes a third-party config surface competing with two platform-native ones (CLAUDE.md + AGENTS.md). |
+| **Maintenance burden** | Medium | The toolkit must document, validate, and handle missing/malformed DESPICABLE.md. This is new infrastructure that needs testing and error handling. YAGNI applies strongly. |
+| **Ecosystem isolation** | Medium | Other tools and agents cannot read DESPICABLE.md. Configuration placed there is invisible to Cursor, Codex, or any non-despicable-agents tooling the project uses. CLAUDE.md content is visible to Claude Code always. |
+
+**Risks of staying with CLAUDE.md sections:**
+
+| Risk | Severity | Detail |
+|------|----------|--------|
+| **Namespace collision** | Low | Despicable-agents sections could conflict with other CLAUDE.md content. Mitigated by using clear section headers (e.g., `## Despicable Agents Configuration`). |
+| **File bloat** | Low | Adding a section to CLAUDE.md increases its size. Mitigated by CLAUDE.md's @-import mechanism for referencing external files when sections grow large. |
+| **Coupling perception** | Low | Users might feel despicable-agents "owns" part of their CLAUDE.md. Mitigated by clear documentation that the section is optional and user-controlled. |
+
+The risk asymmetry is clear: DESPICABLE.md carries 5 medium-to-high risks;
+CLAUDE.md sections carry 3 low risks.
+
+#### 4. When Dedicated Files Win vs. When Sections Win
+
+Based on the broader ecosystem pattern analysis:
+
+**Dedicated file wins when:**
+- The tool has its own parser/runtime that reads the file (ESLint, TypeScript, Docker)
+- Configuration is complex enough to need its own schema/validation
+- The file is consumed by CI/CD pipelines or build tools, not just editors
+- Multiple inheritance or plugin systems are involved
+- The config is machine-generated or machine-maintained
+
+**Section-in-host-file wins when:**
+- Configuration is human-authored guidance, not machine-parsed structure
+- The amount of configuration is small (a few preferences, not a schema)
+- The host file is already read automatically by the platform
+- The config needs to be visible to multiple tools (not just one framework)
+- Simplicity and discoverability matter more than separation of concerns
+
+Despicable-agents configuration matches every criterion in the
+"section-in-host-file" column.
+
+#### 5. Recommended Alternative: Documented Section Convention
+
+Instead of DESPICABLE.md, establish a **documented section convention** for
+consuming projects:
+
+```markdown
+## Despicable Agents
+
+<!-- Optional: project-specific despicable-agents configuration -->
+<!-- See: https://github.com/benpeter/despicable-agents/docs/consuming-project-guide.md -->
+
+### Agent Preferences
+- Prefer security-minion review for all PRs touching auth/
+- Skip sitespeed-minion (no web frontend in this project)
+
+### Nefario Overrides
+- Default mode: PLAN (always require approval before execution)
+- Report directory: docs/reports/
+```
+
+This approach:
+- Is automatically read by Claude Code (zero new infrastructure)
+- Is visible to all Claude Code agents and skills (not just despicable-agents)
+- Works today without any code changes
+- Follows the AGENTS.md philosophy ("just Markdown, use any headings you like")
+- Can be trivially migrated if AGENTS.md support arrives in Claude Code
+
+For local/private overrides, users already have CLAUDE.local.md (gitignored).
+A `## Despicable Agents` section there handles the DESPICABLE.local.md use case.
+
+---
+
+### Proposed Tasks
+
+#### Task 1: Document the Section Convention
+
+**What**: Create a "Consuming Project Guide" in `docs/` that documents the
+recommended `## Despicable Agents` section convention for CLAUDE.md, with
+examples of common configuration patterns.
+
+**Deliverables**: `docs/consuming-project-guide.md` with section templates,
+examples, and explanation of what is configurable.
+
+**Dependencies**: None. This is documentation of the recommended approach.
+
+#### Task 2: Validate Agent Discovery of CLAUDE.md Sections
+
+**What**: Verify that nefario's meta-plan phase already reads CLAUDE.md
+(it does, via Claude Code's automatic loading). Confirm that section-based
+configuration is visible to spawned subagents. Document any gaps.
+
+**Deliverables**: Test results confirming section visibility. If gaps exist,
+minimal fixes to ensure CLAUDE.md sections flow through to agent context.
+
+**Dependencies**: Task 1 (need to know what sections to test).
+
+#### Task 3: Add AGENTS.md Migration Note
+
+**What**: Add a brief note in the consuming project guide about future
+AGENTS.md compatibility. When Claude Code adds AGENTS.md support, the same
+section convention applies -- just move the section to AGENTS.md.
+
+**Deliverables**: One paragraph in the consuming project guide.
+
+**Dependencies**: Task 1.
+
+---
+
+### Risks and Concerns
+
+1. **AGENTS.md convergence risk (6-12 month horizon)**: Claude Code is the
+   last major holdout not supporting AGENTS.md (71% prediction market
+   probability for 2026 adoption). Any config surface invented today should
+   assume it may need to work alongside or migrate to AGENTS.md. A section
+   convention migrates trivially. A dedicated file does not.
+
+2. **Over-engineering risk**: The current external skill integration (Decision
+   28) already works via filesystem scanning and CLAUDE.md precedence. Adding
+   a new config file type creates infrastructure that must be maintained,
+   documented, and tested -- for a problem that may not exist yet. Per the
+   Helix Manifesto: YAGNI.
+
+3. **Platform coupling risk**: Claude Code's automatic CLAUDE.md loading is
+   the most reliable config delivery mechanism available. Any file that is
+   NOT automatically loaded requires explicit `Read` tool calls, which means
+   every agent must know about it. This is fragile and violates KISS.
+
+4. **Cognitive overhead for consuming projects**: A new user evaluating
+   despicable-agents now must learn about DESPICABLE.md in addition to
+   CLAUDE.md, CLAUDE.local.md, and eventually AGENTS.md. Each additional
+   file is a decision point ("where does this config go?") that adds friction.
+
+---
+
+### Additional Agents Needed
+
+- **devx-minion**: Should evaluate the developer experience of the section
+  convention vs. dedicated file from an onboarding and discoverability
+  perspective. The DX of "add a section to your existing CLAUDE.md" vs.
+  "create a new file" is a significant usability difference.
+
+- **software-docs-minion**: Should draft the consuming project guide content
+  if the section convention approach is adopted. The documentation of "how
+  to configure despicable-agents in your project" is a docs deliverable.
+
+No other specialists needed. This is primarily a convention/documentation
+decision, not an implementation task.

--- a/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase2-lucy.md
+++ b/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase2-lucy.md
@@ -1,0 +1,134 @@
+# Domain Plan Contribution: lucy
+
+## Recommendations
+
+### 1. CLAUDE.md Compliance Interaction: Dual-File Validation Creates Unbounded Complexity
+
+If DESPICABLE.md is introduced, lucy must validate both files. This is not merely additive work -- it is multiplicative. Every directive in DESPICABLE.md must be checked for:
+
+- Internal consistency (does DESPICABLE.md contradict itself?)
+- Cross-file consistency (does DESPICABLE.md contradict CLAUDE.md?)
+- Precedence resolution (which wins when they conflict?)
+
+Currently, lucy validates one hierarchy (CLAUDE.md / CLAUDE.local.md / .claude/rules/). Adding DESPICABLE.md and DESPICABLE.local.md creates a second parallel hierarchy with cross-cutting interactions. The validation matrix grows from N directives to N x M directive pairs. This is a structural complexity increase to lucy's compliance checking that is not justified by the configuration use cases identified.
+
+**My recommendation: BLOCK the introduction of DESPICABLE.md.**
+
+### 2. Convention Fragmentation Is the Primary Risk
+
+The core governance concern is: where does a user put "exclude security-minion from reviews"? With a single configuration surface (CLAUDE.md), the answer is unambiguous. With two surfaces (CLAUDE.md + DESPICABLE.md), the answer depends on whether the user considers this "general project configuration" or "agent framework configuration." This is a distinction that:
+
+- Has no crisp boundary (agent behavior IS project behavior when agents operate on the project)
+- Varies by user mental model (some users think of agents as tools, others as team members)
+- Creates discovery problems (a new team member looking at CLAUDE.md sees no agent configuration and assumes there is none)
+
+Decision 5 explicitly states: "All project customization must flow through CLAUDE.md or CLAUDE.local.md." Introducing DESPICABLE.md violates this decision. The decision was made for good reason -- agents are generic specialists, project context belongs in the project's standard configuration surface. Creating a parallel surface fragments that principle.
+
+### 3. Current CLAUDE.md Sections Are Sufficient
+
+The three proposed configuration use cases map cleanly to CLAUDE.md sections:
+
+| Use Case | CLAUDE.md Expression | Example |
+|----------|---------------------|---------|
+| Agent exclusion | Declarative statement in CLAUDE.md | `"Do not use seo-minion or sitespeed-minion for this project"` |
+| Domain spin | Technology preferences section | `"Prefer Fastly for edge compute; prefer Coralogix for observability"` (already works via CLAUDE.local.md) |
+| Orchestration overrides | Workflow section | `"Skip Phase 7 (deployment) in nefario orchestration"` |
+
+These are already the patterns that external-skills.md establishes (Decision 28): "CLAUDE.md explicit preferences (highest) -- If the project's CLAUDE.md declares a skill preference or override, it wins unconditionally." The mechanism exists. No new file is needed.
+
+A dedicated section heading in CLAUDE.md (e.g., `## Agent Team Configuration` or `## despicable-agents`) provides discoverability without introducing a separate file. This is strictly simpler and strictly more discoverable than a parallel file.
+
+### 4. Precedence Rules Would Be Necessary But Unjustifiable
+
+If DESPICABLE.md were introduced, the following precedence questions arise:
+
+- DESPICABLE.local.md vs CLAUDE.local.md: which wins for agent-related directives?
+- DESPICABLE.md vs CLAUDE.md: which wins when CLAUDE.md says "always run security review" and DESPICABLE.md says "exclude security-minion"?
+- DESPICABLE.md vs .claude/rules/*.md: can a rule file override DESPICABLE.md?
+- Parent-directory DESPICABLE.md files: do they recurse upward like CLAUDE.md?
+
+Each question requires a decision. Each decision creates a convention that must be documented, enforced, and debugged when it goes wrong. The existing CLAUDE.md precedence hierarchy (6 tiers, documented in lucy's AGENT.md) already handles all known configuration needs. Adding a parallel hierarchy doubles the precedence surface without addressing a new class of problem.
+
+### 5. SECURITY: Agent Exclusion Can Create Blind Spots (Critical Finding)
+
+This concern applies regardless of whether the configuration surface is DESPICABLE.md or CLAUDE.md, but a separate file makes it harder to audit.
+
+Decision 10 established that security-minion, test-minion, ux-strategy-minion, software-docs-minion, lucy, and margo are ALWAYS reviewers in Phase 3.5. The external-skills.md cross-cutting exception states: "Internal specialists always retain ownership of cross-cutting concerns regardless of external skill specificity. Security-minion, test-minion, accessibility-minion, and governance agents (lucy, margo) are never overridden by external skills."
+
+If project configuration can exclude ALWAYS reviewers, it undermines the architectural safety guarantee. This is the same category of risk as allowing a Dockerfile to disable security scanning -- the configuration surface becomes an attack vector against the quality process.
+
+**Recommendation**: Any configuration mechanism (whether in CLAUDE.md or a hypothetical DESPICABLE.md) must enforce a non-overridable floor:
+
+- security-minion, test-minion, lucy, and margo cannot be excluded from Phase 3.5 review
+- Phase 3.5 itself cannot be skipped via project configuration (only the user can skip it, per Decision 15)
+
+This constraint should be encoded in nefario's AGENT.md and SKILL.md, not just documented. Nefario should validate exclusion lists against the ALWAYS reviewer roster and reject configurations that exclude protected reviewers, surfacing the rejection to the user.
+
+### Summary Position
+
+**BLOCK on DESPICABLE.md introduction.** The proposal:
+
+1. Violates Decision 5 (all customization through CLAUDE.md)
+2. Creates convention fragmentation with no crisp boundary
+3. Multiplies compliance checking complexity without addressing new use cases
+4. Requires precedence rules that duplicate existing CLAUDE.md precedence
+5. Existing CLAUDE.md sections already handle all three identified configuration use cases
+
+**ADVISE on agent exclusion guardrails.** Regardless of the configuration surface decision, the ALWAYS reviewer protection needs explicit enforcement, not just documentation.
+
+---
+
+## Proposed Tasks
+
+### Task 1: Document CLAUDE.md Section Convention for Agent Configuration
+
+**What**: Add a recommended section pattern to `docs/using-nefario.md` showing how consuming projects should configure despicable-agents via CLAUDE.md sections. Include examples for agent exclusion, domain spin, and orchestration overrides.
+
+**Deliverables**: Updated `docs/using-nefario.md` with a "Configuring for Your Project" section containing copy-pasteable CLAUDE.md snippet examples.
+
+**Dependencies**: None. This is documentation of existing capability.
+
+### Task 2: Enforce ALWAYS Reviewer Protection in Nefario
+
+**What**: Add validation logic to nefario's Phase 1 (meta-plan) that checks any agent exclusion directives from CLAUDE.md against the ALWAYS reviewer list. If a protected reviewer is excluded, nefario surfaces a warning and proceeds with the reviewer included. The user can override at the approval gate, but the system does not silently comply.
+
+**Deliverables**: Updated `nefario/AGENT.md` and `skills/nefario/SKILL.md` with ALWAYS reviewer guardrail. Updated `docs/orchestration.md` documenting the guardrail.
+
+**Dependencies**: Task 1 (the CLAUDE.md section convention must be defined before nefario can parse it).
+
+### Task 3: Record Decision Against DESPICABLE.md
+
+**What**: Add a design decision to `docs/decisions.md` recording the evaluation and rejection of DESPICABLE.md, with rationale traceable to Decision 5 and the findings in this analysis.
+
+**Deliverables**: New decision entry in `docs/decisions.md`.
+
+**Dependencies**: Completion of the evaluation (this planning phase).
+
+---
+
+## Risks and Concerns
+
+### Risk 1: Scope Creep Toward DESPICABLE.md in Future
+
+Even if rejected now, the idea may resurface. The decision record (Task 3) mitigates this by documenting the rationale. Future proposals should demonstrate a configuration use case that cannot be expressed as a CLAUDE.md section before re-opening the discussion.
+
+### Risk 2: CLAUDE.md Configuration Parsing Is Unstructured
+
+The current approach relies on natural language directives in CLAUDE.md ("do not use seo-minion"). This is flexible but imprecise. Nefario must interpret these directives heuristically. If the configuration surface grows in complexity, structured configuration (YAML block in CLAUDE.md, for example) may become necessary. But that is a future problem to solve when evidence demands it -- not now (YAGNI).
+
+### Risk 3: ALWAYS Reviewer Bypass Via CLAUDE.local.md
+
+CLAUDE.local.md is gitignored and not team-visible. A user could add "exclude security-minion" in CLAUDE.local.md without team awareness. The guardrail in Task 2 mitigates this by having nefario validate at runtime regardless of which file the directive comes from. The warning is visible in the session output and in the execution report.
+
+### Risk 4: Convention Fragmentation Through .claude/rules/ Files
+
+Even without DESPICABLE.md, users could put agent configuration in `.claude/rules/despicable.md` or similar. This is not a new problem introduced by this evaluation -- it exists today for all CLAUDE.md configuration. The recommended section approach (Task 1) provides a canonical location that reduces the chance of rules-file fragmentation.
+
+---
+
+## Additional Agents Needed
+
+- **security-minion**: Should validate the ALWAYS reviewer protection guardrail (Task 2) from a security perspective. The guardrail is a security control and should be reviewed by the security specialist.
+- **margo**: Should validate that the recommended CLAUDE.md section approach (Task 1) is proportional and not over-engineered. The risk of over-specifying the section format is real.
+
+No other agents needed beyond those already involved.

--- a/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase2-margo.md
+++ b/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase2-margo.md
@@ -1,0 +1,93 @@
+## Domain Plan Contribution: margo
+
+**Verdict: BLOCK -- Do not build DESPICABLE.md. The proposal fails every YAGNI test this project uses.**
+
+### Recommendations
+
+#### 1. There Is No Demonstrated Demand
+
+The framework has exactly one consuming project: the despicable-agents repo itself. Zero external consuming projects exist. The "configuration needs" listed in the proposal (agent exclusion, domain spin, orchestration overrides) are hypothetical. Nobody has filed an issue saying "I need to configure despicable-agents per-project and CLAUDE.md is insufficient." This is a textbook YAGNI violation: building infrastructure for imaginary futures.
+
+The justification test: "When will we need this?" Answer: "Maybe someday when other projects adopt the toolkit." That is the canonical YAGNI failure mode.
+
+#### 2. The Overlay Precedent (Decision 27) Is Directly Applicable
+
+Decision 27 removed ~2,900 lines of overlay infrastructure because it served exactly one agent. The reasoning was explicit: "do not build infrastructure for a pattern until 2+ agents exhibit the need." Replace "agents" with "consuming projects" and the same rule applies with even more force. The overlay mechanism at least had one real user (nefario). DESPICABLE.md has zero real users.
+
+The project literally removed a configuration mechanism 3 days ago for being speculative. Proposing a new configuration mechanism immediately afterward would contradict the project's own freshly-established precedent.
+
+#### 3. CLAUDE.md Already Handles This -- With Zero New Infrastructure
+
+The current design already has a clear, documented answer for project-specific configuration. From `the-plan.md` line 12:
+
+> "Project context belongs in the target project's CLAUDE.md."
+
+From Decision 5 (User-Scope Memory):
+
+> "Project-specific context belongs in the target project's CLAUDE.md, not in agent memory."
+
+This is a settled design principle, not a gap. If a consuming project needs to tell despicable-agents something (exclude certain agents, prefer certain orchestration modes), a `## Despicable Agents` section in that project's CLAUDE.md accomplishes this with:
+
+- Zero new files
+- Zero discovery logic
+- Zero precedence rules
+- Zero documentation for a new file format
+- Zero user education ("what is DESPICABLE.md and how does it relate to CLAUDE.md?")
+
+Every agent already reads CLAUDE.md. Every user already knows CLAUDE.md exists. The marginal cost of a section in an existing file is near zero.
+
+#### 4. Complexity Cost Analysis
+
+**DESPICABLE.md approach** (new file):
+- New file format to document and maintain (1 point)
+- Discovery logic in nefario/agents to find and read DESPICABLE.md (1 point)
+- Precedence rules: DESPICABLE.md vs CLAUDE.md vs DESPICABLE.local.md vs CLAUDE.local.md -- four files, what wins? (3 points)
+- User education: when to put config in which file (1 point)
+- Documentation updates across architecture docs, CLAUDE.md, the-plan.md (1 point)
+- Total: ~7 complexity points for a feature with zero users
+
+**CLAUDE.md section approach** (existing mechanism):
+- Zero new infrastructure
+- Zero new precedence rules
+- Zero documentation changes (CLAUDE.md usage is already documented)
+- Total: 0 complexity points
+
+The delta is 7 points of accidental complexity for zero demonstrated benefit.
+
+#### 5. The "Separation of Concerns" Argument Does Not Hold
+
+The implicit argument is that despicable-agents config would "pollute" CLAUDE.md. But CLAUDE.md is already the designated place for all project-level instructions to Claude Code -- that includes instructions to agents, which are Claude Code agents. A `## Despicable Agents` section is not pollution; it is exactly the kind of content CLAUDE.md was designed for.
+
+If CLAUDE.md becomes too large, the right response is to organize it better (headings, sections), not to fragment configuration across multiple files with different names and overlapping purposes.
+
+#### 6. Decision 26 Already Solved Portability Without Config Files
+
+Decision 26 explicitly rejected a configuration file (`.nefario.yml`) as YAGNI. The reasoning: "detection logic handles all known cases without user configuration." That decision was made 2 days ago. Nothing has changed since then to invalidate it.
+
+### Proposed Tasks
+
+**Task 1: Do nothing. Close the evaluation with a "not now" decision.**
+
+- **What to do**: Record a decision (Decision 29) that DESPICABLE.md was evaluated and deferred. State the re-introduction trigger clearly: "Revisit when 2+ consuming projects demonstrate configuration needs that a `## Despicable Agents` section in CLAUDE.md cannot serve."
+- **Deliverables**: One entry in `docs/decisions.md`
+- **Dependencies**: None
+
+**Task 2 (optional): Document the CLAUDE.md section convention**
+
+- **What to do**: If there is genuine concern that future consuming projects will not know how to configure despicable-agents, add a 3-5 line section to the despicable-agents README or docs explaining: "To configure despicable-agents for your project, add a `## Despicable Agents` section to your project's CLAUDE.md."
+- **Deliverables**: 3-5 lines in an existing doc file
+- **Dependencies**: None
+
+These two tasks are the entire scope. Any expansion beyond this is scope creep.
+
+### Risks and Concerns
+
+1. **Risk of building it anyway**: The primary risk is that the evaluation process itself creates momentum toward building something. "We evaluated it, we might as well build it" is a common trap. The evaluation should produce a clear "no" and stop.
+
+2. **Risk of premature abstraction**: If DESPICABLE.md is built speculatively and the actual configuration needs of real consuming projects turn out to be different from what was imagined, the framework will either need to be reworked or will constrain how projects actually configure things. Building configuration infrastructure before understanding real usage patterns is premature abstraction.
+
+3. **Risk of contradiction**: Building DESPICABLE.md immediately after removing the overlay mechanism (Decision 27) for the same YAGNI reasons would undermine the project's credibility on simplicity principles. It signals that the team does not actually follow its own rules.
+
+### Additional Agents Needed
+
+None. This evaluation does not require additional specialist input. The answer is straightforward application of principles the project has already established and recently reinforced.

--- a/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase2-software-docs-minion.md
+++ b/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase2-software-docs-minion.md
@@ -1,0 +1,213 @@
+## Domain Plan Contribution: software-docs-minion
+
+### Recommendations
+
+**DESPICABLE.md has clear wins and aligns with documentation minimalism principles.**
+
+The documentation impact analysis reveals that introducing DESPICABLE.md (with DESPICABLE.local.md for user-private overrides) is the superior approach compared to CLAUDE.md sections or status quo. Here is why:
+
+#### 1. Dedicated File (DESPICABLE.md) Approach
+
+**Pros:**
+- **Separation of concerns**: Keeps framework-specific configuration out of general CLAUDE.md instructions
+- **Discoverability**: New contributors immediately see despicable-agents has configuration when they see DESPICABLE.md
+- **Reusability**: Configuration pattern can be copied across projects without extracting from larger CLAUDE.md
+- **Versioning**: Framework config changes are isolated in git history from general tooling changes
+- **Progressive disclosure**: Users learn general Claude Code conventions first (CLAUDE.md), then framework specifics (DESPICABLE.md)
+
+**Cons:**
+- **One more file**: Adds to file count in project root
+- **Documentation burden**: Need to document the file's existence and precedence rules
+
+#### 2. CLAUDE.md Section Approach
+
+**Pros:**
+- **Single source**: All project instructions in one place
+- **No new convention**: Uses existing Claude Code pattern
+
+**Cons:**
+- **Poor separation**: Framework config mixes with general project instructions
+- **Discovery friction**: Contributors must read full CLAUDE.md to find despicable-agents settings
+- **Reusability friction**: Copying framework config requires manual extraction
+- **Version noise**: Framework updates pollute general project instruction history
+
+#### 3. Status Quo (No Framework Config)
+
+**Cons:**
+- **Repeated patterns**: Each project rediscovers conventions like "external skill precedence goes in CLAUDE.md"
+- **No guidance**: Users do not know where to put despicable-specific configuration
+
+**Recommendation: Adopt DESPICABLE.md + DESPICABLE.local.md pattern.**
+
+The separation of concerns benefit alone justifies the extra file. The documentation burden is modest (one getting-started section, one reference doc). This aligns with Decision 5's principle: "Project-specific context belongs in the target project's CLAUDE.md" -- by creating DESPICABLE.md, we refine that to "framework-specific context belongs in DESPICABLE.md."
+
+---
+
+### Proposed Tasks
+
+#### Task 1: Document DESPICABLE.md Convention in Architecture Docs
+
+**What:** Add a new section to `docs/architecture.md` (Design Philosophy) explaining the DESPICABLE.md pattern.
+
+**Deliverables:**
+- 4-6 paragraph section in `docs/architecture.md` under "Design Philosophy" heading
+- Explains when to use DESPICABLE.md vs CLAUDE.md
+- States precedence rules (DESPICABLE.local.md > DESPICABLE.md > CLAUDE.md for framework-specific config)
+- Examples of what belongs in each file
+
+**Dependencies:** None (can run immediately)
+
+---
+
+#### Task 2: Create DESPICABLE.md Configuration Reference
+
+**What:** Create `docs/consuming-projects.md` (new file) with full reference for DESPICABLE.md and DESPICABLE.local.md.
+
+**Deliverables:**
+- New file at `docs/consuming-projects.md`
+- Structure:
+  - Purpose and motivation (why DESPICABLE.md exists)
+  - File locations and precedence
+  - Configuration sections (external skill preferences, agent behavior overrides, orchestration defaults)
+  - Complete examples for common scenarios (Rails project, Next.js project, Python service)
+  - Template DESPICABLE.md file (minimal starter)
+- Linked from `docs/architecture.md` sub-documents table
+
+**Dependencies:** Task 1 (architecture section should exist before detailed reference)
+
+---
+
+#### Task 3: Update External Skills Documentation
+
+**What:** Update `docs/external-skills.md` to reference DESPICABLE.md as the canonical location for skill precedence overrides.
+
+**Deliverables:**
+- Edit to "Precedence Rules" section in `docs/external-skills.md`
+- Change from "If the project's CLAUDE.md declares a skill preference" to "If DESPICABLE.md or CLAUDE.md declares a skill preference"
+- Add note: "Prefer DESPICABLE.md for framework-specific preferences; use CLAUDE.md for general project tooling preferences"
+- Update example to show DESPICABLE.md usage
+
+**Dependencies:** Task 2 (reference doc should exist before we point to the pattern)
+
+---
+
+#### Task 4: Update Using Nefario Guide
+
+**What:** Add "Configuration" subsection to `docs/using-nefario.md` explaining how to customize nefario behavior in consuming projects.
+
+**Deliverables:**
+- New "Configuration" section in `docs/using-nefario.md` (insert after "Working Directory" section)
+- 2-3 paragraphs explaining DESPICABLE.md purpose for consuming projects
+- Link to `docs/consuming-projects.md` for full reference
+- Quick example showing how to set orchestration defaults
+
+**Dependencies:** Task 2 (must link to the reference doc)
+
+---
+
+#### Task 5: Create Template DESPICABLE.md
+
+**What:** Add `templates/DESPICABLE.md` to the repository with commented examples.
+
+**Deliverables:**
+- New file at `templates/DESPICABLE.md`
+- Heavily commented template showing:
+  - External skill precedence overrides
+  - Agent behavior customization
+  - Orchestration defaults (e.g., "always skip Phase 7 deployment")
+  - Common project types (monorepo, microservice, documentation site)
+- Instructions at top: "Copy to your project root and customize"
+
+**Dependencies:** Task 2 (template should match reference documentation structure)
+
+---
+
+#### Task 6: Update Deployment Documentation
+
+**What:** Add "For Consuming Projects" section to `docs/deployment.md` pointing to configuration docs.
+
+**Deliverables:**
+- New section in `docs/deployment.md` after "Using the Toolkit"
+- 1-2 paragraphs explaining that consuming projects can customize via DESPICABLE.md
+- Link to `docs/consuming-projects.md`
+- Note that configuration is optional (zero-config works)
+
+**Dependencies:** Task 2 (must link to reference doc)
+
+---
+
+#### Task 7: Update README with Configuration Pointer
+
+**What:** Add one-line mention in project README about configuration for consuming projects.
+
+**Deliverables:**
+- Edit to `/README.md` (likely in "Structure" or after "Deployment" section)
+- Single line: "For project-specific configuration, see [Consuming Projects Guide](docs/consuming-projects.md)"
+- Or add to existing "Using the Toolkit" section if one exists in README
+
+**Dependencies:** Task 2 (must have reference doc to link to)
+
+---
+
+### Risks and Concerns
+
+#### Risk 1: Configuration Sprawl
+
+**Concern:** Users put everything in DESPICABLE.md instead of maintaining proper separation.
+
+**Mitigation:** Clear documentation with "belongs in DESPICABLE.md" vs "belongs in CLAUDE.md" decision tree. Template file with strong comments showing boundaries.
+
+#### Risk 2: Precedence Confusion
+
+**Concern:** Users are confused about DESPICABLE.md vs CLAUDE.md vs DESPICABLE.local.md precedence.
+
+**Mitigation:** Explicit precedence rules in every doc that mentions the files. Visual diagram in `docs/consuming-projects.md` showing how settings cascade.
+
+#### Risk 3: Documentation Drift
+
+**Concern:** As despicable-agents evolves, DESPICABLE.md examples become outdated.
+
+**Mitigation:** Template file and examples live in the repository and are versioned. Updates to agent behavior trigger review of consuming-projects.md examples (add to checklist for spec version bumps).
+
+#### Risk 4: Over-Engineering
+
+**Concern:** We are creating infrastructure for a problem that does not exist yet (violates YAGNI).
+
+**Counter-evidence:** The problem already exists -- external-skills.md references "project's CLAUDE.md" for preferences, meaning projects are already putting framework config somewhere. This formalizes existing practice rather than speculating about future needs. The one-agent rule (Decision 27) would say "wait for 2 projects to need this" -- but this is a toolkit meant to be used by multiple projects, so we cannot wait for 2 consumers before documenting consumption patterns.
+
+---
+
+### Additional Agents Needed
+
+**None.** The current team is sufficient.
+
+- **software-docs-minion** (me): Owns all documentation tasks listed above
+- **lucy**: Should review the precedence rules and configuration boundaries for intent alignment
+- **margo**: Should review for simplicity (are we over-engineering the configuration pattern?)
+- **devx-minion**: Optional consult on whether the template and configuration pattern creates good developer experience for consuming projects
+
+No new specialists are required. This is a documentation exercise with governance review.
+
+---
+
+### Documentation Burden Assessment
+
+**Dedicated File (DESPICABLE.md) Approach:**
+- New files: 1 reference doc (~800-1200 lines), 1 template (~50-80 lines)
+- Updated files: 4 existing docs (architecture.md, external-skills.md, using-nefario.md, deployment.md)
+- Total effort: ~1200-1500 lines of new content, ~100-150 lines of edits
+- Maintenance: Template needs updates when agent roster or delegation rules change
+
+**CLAUDE.md Section Approach:**
+- New files: None
+- Updated files: 1 doc (create "Configuration" guide as new doc, but smaller since no precedence rules needed)
+- Total effort: ~400-600 lines of new content
+- Maintenance: Same as dedicated file (examples need updates)
+
+**Status Quo Approach:**
+- New files: None
+- Updated files: None
+- Total effort: 0 lines
+- Maintenance: 0 (but users rediscover patterns, ask questions, and create inconsistent conventions)
+
+**Verdict:** Dedicated file adds 800-1000 lines over CLAUDE.md section approach, but delivers significantly better separation of concerns, discoverability, and reusability. The incremental documentation cost is justified by long-term benefits to consuming projects.

--- a/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase3-synthesis.md
+++ b/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase3-synthesis.md
@@ -1,0 +1,194 @@
+# Phase 3: Synthesis -- Evaluate DESPICABLE.md Configuration
+
+## Delegation Plan
+
+**Team name**: evaluate-despicable-md-config
+**Description**: Produce a decision document evaluating whether consuming projects should have dedicated DESPICABLE.md / DESPICABLE.local.md files. Consultation only -- no code.
+
+---
+
+### Conflict Resolution
+
+**Core conflict**: 4 of 5 specialists (gru, lucy, margo, devx-minion) recommend against DESPICABLE.md. 1 specialist (software-docs-minion) recommends for it.
+
+**Resolution: Reject DESPICABLE.md. Recommend CLAUDE.md section convention instead.**
+
+Rationale for siding with the majority:
+
+1. **Precedent weight**: Decisions 26 (rejected .nefario.yml) and 27 (removed overlay mechanism) were made within the past week. Both applied YAGNI to reject configuration infrastructure with zero demonstrated demand. Introducing DESPICABLE.md immediately after these decisions would contradict freshly-established project principles.
+
+2. **Zero consumers**: The toolkit has exactly one consuming project (itself). Building per-project configuration infrastructure for zero external consumers is the textbook YAGNI failure mode that margo identified.
+
+3. **Platform integration**: CLAUDE.md is automatically loaded by Claude Code. DESPICABLE.md would require explicit Read calls in agents -- fragile discovery that gru, devx-minion, and lucy all flagged as a high-severity risk.
+
+4. **Industry direction**: gru's analysis shows the ecosystem consolidating toward fewer config files (AGENTS.md standard, ESLint flat config trajectory, Cursor consolidating .cursorrules). Introducing a new dedicated file swims against this tide.
+
+5. **Complexity asymmetry**: margo's cost analysis (7 complexity points for DESPICABLE.md vs. 0 for CLAUDE.md sections) is uncontested by software-docs-minion's contribution, which acknowledges the overhead but argues separation of concerns justifies it.
+
+**Why software-docs-minion's position was not adopted**: The separation-of-concerns argument is valid in principle but disproportionate for the current configuration surface. As devx-minion noted, the despicable-agents config is closer to Prettier (few preferences) than ESLint (complex plugin architecture). The configuration use cases identified (agent exclusion, domain spin, orchestration overrides) are either already handled by existing CLAUDE.md patterns, should not be configurable at all (ALWAYS reviewers, Phase 3.5 skip), or have too low utility to justify new infrastructure. software-docs-minion's documentation burden estimate (1200-1500 lines for dedicated file vs. 400-600 for CLAUDE.md section) itself demonstrates the overhead differential.
+
+---
+
+### Task 1: Write ADR Decision Document
+
+- **Agent**: software-docs-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: default
+- **Blocked by**: none
+- **Approval gate**: no
+- **Prompt**: |
+    Write a new decision entry (Decision 29) in `/Users/ben/github/benpeter/despicable-agents/docs/decisions.md`.
+
+    ## Context
+
+    The team evaluated whether consuming projects should have dedicated
+    DESPICABLE.md and DESPICABLE.local.md files for framework-specific
+    configuration of the despicable-agents toolkit. Five specialists were
+    consulted: gru (technology radar), lucy (governance/compliance),
+    margo (simplicity/YAGNI), devx-minion (developer experience), and
+    software-docs-minion (documentation architecture).
+
+    ## Decision to Record
+
+    **Decision 29: Reject DESPICABLE.md, Adopt CLAUDE.md Section Convention**
+
+    Use this format (matching the existing table format in decisions.md):
+
+    ```
+    ### Decision 29: Reject DESPICABLE.md, Adopt CLAUDE.md Section Convention
+
+    | Field | Value |
+    |-------|-------|
+    | **Status** | Decided |
+    | **Date** | 2026-02-12 |
+    | **Choice** | ... |
+    | **Alternatives rejected** | ... |
+    | **Rationale** | ... |
+    | **Consequences** | ... |
+    ```
+
+    Field content:
+
+    **Choice**: Do not introduce DESPICABLE.md or DESPICABLE.local.md. Consuming
+    projects configure despicable-agents behavior via a `## Despicable Agents`
+    section in their existing CLAUDE.md (public) and CLAUDE.local.md (private).
+    Nefario reads this section via Claude Code's automatic CLAUDE.md loading --
+    no new discovery logic required. Re-evaluate when 2+ consuming projects
+    demonstrate configuration needs that CLAUDE.md sections cannot serve,
+    or when Claude Code adopts AGENTS.md support (whichever comes first).
+
+    **Alternatives rejected**: (1) Dedicated DESPICABLE.md + DESPICABLE.local.md
+    files for framework-specific config. Rejected because: zero consuming
+    projects exist to demonstrate need (YAGNI); contradicts Decisions 26
+    (.nefario.yml rejected) and 27 (overlay removal) made within the same week;
+    requires explicit Read calls in agents since Claude Code does not auto-load
+    custom files; creates precedence complexity (4-file hierarchy); industry
+    consolidating toward fewer config files (AGENTS.md standard). (2) Status quo
+    with no guidance. Rejected because consuming projects would rediscover
+    configuration patterns inconsistently.
+
+    **Rationale**: 4 of 5 consulted specialists recommended against DESPICABLE.md.
+    Key factors: CLAUDE.md is auto-loaded by Claude Code (zero infrastructure);
+    the configuration surface is small (few preferences, not a plugin architecture);
+    Decision 5 establishes CLAUDE.md as the canonical project customization surface;
+    the ecosystem is consolidating config files, not proliferating them. The
+    dissenting view (software-docs-minion) valued separation of concerns, but the
+    configuration volume does not justify a dedicated file -- the analogy is
+    Prettier (section in package.json) not ESLint (dedicated file). Lucy
+    additionally identified that any configuration mechanism must protect ALWAYS
+    reviewers (security-minion, test-minion, lucy, margo) from exclusion --
+    this constraint applies regardless of config surface and should be enforced
+    in nefario.
+
+    **Consequences**: Consuming projects add a `## Despicable Agents` section
+    to CLAUDE.md for framework preferences. CLAUDE.local.md handles private/local
+    overrides. No new files, discovery logic, or precedence rules needed. Future
+    documentation should include examples of the section convention. ALWAYS
+    reviewer protection should be enforced in nefario (separate future task,
+    not part of this decision). If AGENTS.md support arrives in Claude Code,
+    the section convention migrates trivially.
+
+    ## Placement
+
+    Add this decision under a new section heading:
+
+    ```
+    ## Configuration (Decisions 29+)
+    ```
+
+    Place it after the existing "Orchestration Improvements (Decisions 25-28)"
+    section, at the end of the file.
+
+    ## What NOT to do
+
+    - Do not modify any other decisions
+    - Do not create new files -- only append to the existing decisions.md
+    - Do not add content beyond the decision entry and its section heading
+    - Do not include the dissenting view as a separate section -- it is covered
+      in the Rationale field
+
+- **Deliverables**: Updated `/Users/ben/github/benpeter/despicable-agents/docs/decisions.md` with Decision 29
+- **Success criteria**: Decision 29 follows the same table format as Decisions 1-28; captures the recommendation, rejected alternatives, rationale (including dissent), consequences, and re-introduction trigger
+
+---
+
+### Cross-Cutting Coverage
+
+- **Testing**: Not applicable -- this task produces a decision document, not code or configuration. No executable output to test.
+- **Security**: Covered within the decision rationale. Lucy identified the ALWAYS reviewer protection concern. The decision document captures this as a consequence (future enforcement task). No security review of the document itself is needed.
+- **Usability -- Strategy**: Covered by the evaluation itself. All 5 specialists assessed the developer/user experience implications. The decision to use CLAUDE.md sections was driven by discoverability, cognitive overhead, and onboarding friction analysis from devx-minion and gru.
+- **Usability -- Design**: Not applicable -- no user-facing interfaces produced.
+- **Documentation**: The deliverable IS documentation. software-docs-minion authors it. No separate documentation review needed.
+- **Observability**: Not applicable -- no runtime components produced.
+
+### Architecture Review Agents
+
+- **Always**: security-minion, test-minion, ux-strategy-minion, software-docs-minion, lucy, margo
+- **Conditional**: none triggered
+
+Note: Phase 3.5 applies to this plan. However, given that the deliverable is a single decision entry in an existing file, and that all 6 ALWAYS reviewers' domains were already represented in the specialist consultation (lucy, margo, devx-minion covered governance and usability; gru covered security implications; software-docs-minion is the authoring agent), the review prompts should focus on verifying the decision document accurately represents the consultation findings rather than introducing new architectural concerns.
+
+### Conflict Resolutions
+
+| Conflict | Resolution | Rationale |
+|----------|-----------|-----------|
+| software-docs-minion (ADOPT) vs. gru, lucy, margo, devx-minion (REJECT) | REJECT DESPICABLE.md | 4-to-1 consensus; YAGNI precedent (Decisions 26, 27); zero consumers; platform auto-loading advantage; industry consolidation trend. Dissenting separation-of-concerns argument valid but disproportionate for current config surface. |
+
+### Risks and Mitigations
+
+| Risk | Source | Severity | Mitigation |
+|------|--------|----------|------------|
+| Decision reopened without new evidence | margo | Low | Decision 29 includes explicit re-introduction trigger: "2+ consuming projects demonstrate need OR Claude Code adopts AGENTS.md" |
+| CLAUDE.md config parsing is unstructured | lucy | Low | Current config is natural language interpreted by LLM. If complexity grows, structured blocks (YAML in CLAUDE.md) can be added later. YAGNI for now. |
+| ALWAYS reviewer bypass via CLAUDE.local.md | lucy | Medium | Documented as consequence in Decision 29. Enforcement in nefario is a separate future task (not in scope of this consultation). |
+| AGENTS.md convergence changes the landscape | gru | Medium | Decision 29 includes re-evaluation trigger for AGENTS.md adoption. Section convention migrates trivially to AGENTS.md. |
+| Evaluation creates momentum to build anyway | margo | Low | Decision document explicitly states "do not build" with clear re-introduction criteria. |
+
+### Execution Order
+
+```
+Batch 1: Task 1 (write Decision 29)
+  |
+Phase 3.5: Architecture review of the decision document
+  |
+Done -- single deliverable, presented to user
+```
+
+No approval gates. The decision document is the final deliverable presented directly to the user for review. Zero gates is appropriate because:
+- Blast radius is low (one file edit, no downstream tasks)
+- Easy to reverse (decision entries can be amended)
+- The user explicitly requested a consultation, so the output IS the approval artifact
+
+### External Skills
+
+No external skills detected in project.
+
+### Verification Steps
+
+1. Decision 29 exists in `docs/decisions.md` with correct table format
+2. The Choice field captures the CLAUDE.md section convention recommendation
+3. The Alternatives rejected field covers both DESPICABLE.md and status quo
+4. The Rationale field includes the dissenting view and why it was not adopted
+5. The Consequences field includes the re-introduction trigger and ALWAYS reviewer protection note
+6. The decision is placed under a new "Configuration (Decisions 29+)" section heading

--- a/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase3.5-security-minion.md
+++ b/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase3.5-security-minion.md
@@ -1,0 +1,9 @@
+## Review Verdict: security-minion
+
+ADVISE
+
+1. **ALWAYS Reviewer Bypass Risk**: CLAUDE.local.md could be used to exclude security-minion, test-minion, lucy, or margo. Documented as future enforcement task but remains open gap. Tag as security debt with priority.
+
+2. **Configuration Parsing Security Model**: Unstructured LLM interpretation means no formal validation or allowlist enforcement. Document security boundaries for config sections (e.g., "ALWAYS reviewers cannot be excluded" as documented constraint).
+
+Neither blocks the decision document.

--- a/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase3.5-software-docs-minion.md
+++ b/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/phase3.5-software-docs-minion.md
@@ -1,0 +1,9 @@
+## Review Verdict: software-docs-minion
+
+ADVISE
+
+1. **Missing consuming-projects guide**: Decision 29 captures the "what" and "why" but not actionable guidance for consuming projects. Developers won't know how to implement the recommended section convention. Recommend a short guide (200-300 lines) showing example CLAUDE.md sections, precedence rules, configurable vs hard-constrained preferences.
+
+2. **Format consistency verified**: Proposed decision format matches conventions in existing decisions.md.
+
+Both non-blocking. Decision document sufficient for consultation; guide addresses usability gap for future adopters.

--- a/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/prompt.md
+++ b/docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/prompt.md
@@ -1,0 +1,18 @@
+Evaluate DESPICABLE.md as project-local configuration for the framework
+
+**Outcome**: The team reaches a well-reasoned decision on whether consuming projects should have dedicated DESPICABLE.md and DESPICABLE.local.md files for framework-specific configuration, so that project instructions for despicable-agents stay separated from general CLAUDE.md concerns without requiring users to modify files owned by other tools.
+
+**Success criteria**:
+- Clear recommendation (adopt, defer, or reject) with rationale
+- Precedence rules documented if adopted (DESPICABLE.md vs CLAUDE.md conflicts)
+- At least gru, lucy, margo, and devx-minion consulted
+- YAGNI analysis: real demand vs speculative need
+- Alternative approaches evaluated (e.g., a `## Despicable Agents` section in CLAUDE.md)
+
+**Scope**:
+- In: File naming convention, .md vs .local.md split, interaction with existing CLAUDE.md/CLAUDE.local.md, discoverability for adopters, what configuration options these files would support (agent exclusion, domain spin, orchestration overrides)
+- Out: Implementation of file parsing, changes to agent runtime, changes to nefario orchestration code
+
+**Constraints**:
+- Consultation only -- produce a decision document, not code
+- Must include input from gru, lucy, margo, and devx-minion at minimum


### PR DESCRIPTION
## Summary

- Consultation with 5 specialists and 6 architecture reviewers evaluated whether consuming projects should have dedicated `DESPICABLE.md` / `DESPICABLE.local.md` files
- 4 of 5 specialists recommended against; 1 dissented on separation-of-concerns grounds
- **Decision: Reject DESPICABLE.md.** Use `## Despicable Agents` section in CLAUDE.md instead
- Re-introduction trigger: 2+ consuming projects demonstrate need OR Claude Code adopts AGENTS.md

## Key findings

- Zero consuming projects exist — no demonstrated demand (YAGNI)
- CLAUDE.md is auto-loaded by Claude Code; DESPICABLE.md would need explicit discovery in 27 agents
- Industry consolidating config surfaces (AGENTS.md standard, 40k+ repos)
- All proposed config options already work via CLAUDE.md sections
- Decisions 26 + 27 set direct YAGNI precedent this week

## Files

| File | Change |
|------|--------|
| `docs/decisions.md` | Decision 29 entry |
| `docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config.md` | Full consultation report |
| `docs/history/nefario-reports/2026-02-12-092651-evaluate-despicable-md-config/` | Working files (10 specialist outputs) |

## Test plan

- [x] Decision 29 follows existing table format in decisions.md
- [x] Report follows v3 template conventions
- [ ] Verify report renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)