### PR TITLE
docs: add nefario advisory report on serverless bias correction

### DIFF
--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction.md
@@ -1,0 +1,220 @@
+---
+type: nefario-report
+version: 3
+date: "2026-02-13"
+time: "11:07:15"
+task: "Advisory: correct serverless bias in agent system"
+mode: plan
+agents-involved: [nefario, iac-minion, margo, gru, lucy, devx-minion, security-minion, test-minion, ux-strategy-minion]
+task-count: 0
+gate-count: 0
+outcome: completed
+---
+
+# Advisory: Correct Serverless Bias in Agent System
+
+## Summary
+
+Five specialists independently confirmed a structural anti-serverless bias in the despicable-agents system, distributed across three compounding gaps: iac-minion has zero serverless knowledge, margo's complexity heuristics penalize novelty instead of operational burden, and the delegation table has no serverless routing. All specialists unanimously recommend against a new agent -- the fix is expanding iac-minion's remit, recalibrating margo's heuristics, updating the delegation table, and providing a CLAUDE.md template for target projects to declare serverless-first preferences.
+
+## Original Prompt
+
+> Advisory-only request. Create a meaningful report with the team to consult on the following question, don't act. No execution or post-processing.
+>
+> Question: When starting greenfield, the system thinks serverless is complicated and flags it as overengineering / YAGNI / anti-KISS, but that's a wrong bias. Serverless is super simple. Maybe we need a serverless agent in the roster? At a minimum, we must correct the bias in a meaningful way and find the right entry point for that (CLAUDE.md? lucy?).
+
+## Key Design Decisions
+
+#### No New Agent -- Expand Existing Knowledge
+
+**Rationale**:
+- All 5 specialists independently reached the same conclusion: the gap is knowledge, not roster
+- 27 agents is already at the upper bound of manageable complexity
+- A serverless-minion would have boundary conflicts with iac-minion, edge-minion, frontend-minion, and api-design-minion
+- Filling iac-minion's knowledge gap is cheaper and less disruptive than adding a 28th agent
+
+**Alternatives Rejected**:
+- Dedicated serverless-minion: boundary conflicts with 4 existing agents, adds complexity without proportional value
+
+#### CLAUDE.md for Preferences, Agents for Capability
+
+**Rationale**:
+- Agents are generic specialists under Apache 2.0 -- hardcoding "serverless-first" makes them opinionated
+- CLAUDE.md is the most enforceable location (lucy can produce APPROVE/BLOCK verdicts against it)
+- Follows the existing pattern (CLAUDE.local.md carries vendor preferences, agents stay generic)
+- Per-project customizable: different projects can have different infrastructure preferences
+
+**Alternatives Rejected**:
+- Baking preference into iac-minion AGENT.md: violates publishability constraint, forces opinion on all users
+- Adding to despicable-agents' own CLAUDE.md: wrong scope (governs agent development, not target projects)
+- Making margo block self-hosted proposals: margo enforces simplicity, not infrastructure topology
+
+#### Operational Burden Over Novelty in Complexity Scoring
+
+**Rationale**:
+- Current "New service: 5 points" treats `vercel deploy` the same as Docker + Terraform + Caddy
+- Self-managed services carry ongoing operational burden (patching, scaling, incident response) that was underweighted
+- Splitting to self-managed (8pts) vs managed/serverless (3pts) corrects the structural bias
+
+**Alternatives Rejected**:
+- Keeping flat scoring: perpetuates the bias
+- devx-minion's 25-point Kubernetes scale: different measurement (DX benchmark, not complexity budget)
+
+### Conflict Resolutions
+
+**Serverless routing ownership**: devx-minion proposed edge-minion as primary for serverless deployment config. iac-minion and gru proposed iac-minion. Resolved: iac-minion owns deployment decisions and platform config; edge-minion owns edge-specific implementation. Preserves existing boundary.
+
+**Margo's scope with infrastructure opinions**: lucy cautioned that making margo opinionated about infrastructure topology is scope creep. Resolved: margo detects when infrastructure complexity is disproportionate (a simplicity question, in scope), without prescribing alternatives (an infrastructure preference, out of scope).
+
+**Complexity budget vs DX scoring**: margo's two-tier budget and devx-minion's deployment complexity score are incompatible scales. Resolved: margo's split (8/3) goes into the Complexity Budget; devx-minion's scoring stays as a separate DX benchmark in devx-minion's knowledge.
+
+## Phases
+
+### Phase 1: Meta-Plan
+
+Nefario analyzed the question and identified five specialists: iac-minion (self-assessment of knowledge gap), margo (complexity heuristic recalibration), gru (technology maturity assessment), lucy (convention entry point design), and devx-minion (developer experience perspective). The meta-plan identified that the bias is structural and emergent -- not from a single rule but from three compounding gaps across agent knowledge, heuristic framing, and task routing. No external skills were relevant.
+
+### Phase 2: Specialist Planning
+
+Five specialists were consulted in parallel, all at opus. Key findings by agent:
+
+**iac-minion** performed a candid self-assessment: "The bias is real and I am its primary vector." The word "serverless" appears zero times in its AGENT.md. Its Infrastructure Design Approach never asks "does this project need infrastructure at all?" Estimated 10:1 operational complexity ratio between its default stack and serverless. Proposed a Step 0 deployment strategy triage and bounded serverless knowledge additions.
+
+**margo** identified three compounding factors in its own heuristics: complexity budget measures novelty not burden, boring tech examples implicitly equate "boring" with "self-hosted," and no detection pattern exists for infrastructure over-engineering. Proposed splitting service costs (self-managed 8pts, managed 3pts), adding serverless to boring tech, and adding an Infrastructure Over-Engineering detection pattern.
+
+**gru** classified AWS Lambda and Cloudflare Workers as ADOPT, Vercel as TRIAL, Netlify as TRIAL with reservations, and Deno Deploy as ASSESS. Confirmed serverless is legitimately boring technology for qualifying patterns. Recommended against a 28th agent. Flagged vendor lock-in as highest-severity risk.
+
+**lucy** concluded that CLAUDE.md is the most enforceable entry point, citing three properties: enforceability (APPROVE/BLOCK verdicts), publishability (agents stay generic), and the three-gap nature of the bias (no single fix suffices). Recommended a layered combination: CLAUDE.md for preference, agents for capability, delegation table for routing.
+
+**devx-minion** quantified a 50:1 time-to-first-deploy penalty (47 seconds for `vercel deploy` vs 1-4 hours for Docker + Terraform + Caddy). Proposed a 5-level escalation path from static hosting (Level 0) to self-managed infrastructure (Level 4). Core principle: "Complexity should be opt-in, not opt-out."
+
+No specialists recommended additional agents beyond the initial five.
+
+### Phase 3: Synthesis
+
+Nefario consolidated the five contributions into a unified advisory. All specialists converged on the same corrective architecture with no fundamental disagreements. Three minor conflicts were resolved (routing ownership, margo scope, budget scoring). The synthesis produced four prioritized recommendations: (1) expand iac-minion, (2) recalibrate margo, (3) update delegation table, (4) provide CLAUDE.md template. An implementation roadmap was included for if/when the user decides to act.
+
+### Phase 3.5: Architecture Review
+
+Five mandatory reviewers (security-minion, test-minion, ux-strategy-minion, lucy, margo) reviewed the synthesis. No discretionary reviewers applied (advisory-only, no code output).
+
+Results: 2 APPROVE (lucy, ux-strategy-minion), 3 ADVISE (security-minion, test-minion, margo), 0 BLOCK.
+
+Security-minion advised adding serverless security patterns to iac-minion's knowledge, framing vendor lock-in as a security risk (not just cost/portability), and adding security-based escalation triggers (compliance forensics, mTLS, BYOK). Test-minion advised adding calibration examples to the triage decision tree and defining pass/fail criteria for Phase E verification. Margo advised that the 5-level escalation ladder is over-specified for an advisory, the four delegation table rows could be two, and Phase E verification is premature for changes that don't yet exist.
+
+### Phase 4: Execution
+
+Skipped (advisory-only).
+
+### Phase 5: Code Review
+
+Skipped (advisory-only).
+
+### Phase 6: Test Execution
+
+Skipped (advisory-only).
+
+### Phase 7: Deployment
+
+Skipped (advisory-only).
+
+### Phase 8: Documentation
+
+Skipped (advisory-only).
+
+<details>
+<summary>Agent Contributions (5 planning, 5 review)</summary>
+
+### Planning
+
+**iac-minion**: Self-assessed a complete serverless knowledge gap. Proposed deployment strategy triage as Step 0, bounded serverless knowledge (Vercel deep, CF Pages/Lambda moderate), decision-first knowledge restructuring, and a 4-level escalation path.
+- Adopted: All recommendations adopted into synthesis
+- Risks flagged: Margo coordination required or complexity budget will overrule serverless recommendations
+
+**margo**: Identified three heuristic flaws (novelty-based scoring, self-hosted boring tech bias, missing infra over-engineering detection). Proposed split service costs, boring tech additions, and new detection patterns.
+- Adopted: All recommendations adopted
+- Risks flagged: Over-correction risk; counter-signals must be equally prominent
+
+**gru**: Classified serverless platforms on adopt/trial/assess/hold. Lambda and CF Workers at ADOPT. Confirmed serverless is boring technology. Recommended against 28th agent.
+- Adopted: All recommendations adopted; technology maturity assessment referenced in synthesis
+- Risks flagged: Vendor lock-in accumulation (highest severity)
+
+**lucy**: Analyzed convention enforceability across entry points. Concluded CLAUDE.md is most enforceable; agents stay generic; bias is three gaps not one convention.
+- Adopted: Layered approach (CLAUDE.md preference + agent capability + routing) adopted
+- Risks flagged: Publishability constraint if preferences baked into agents
+
+**devx-minion**: Quantified 50:1 TTFD penalty. Designed 5-level escalation path. Proposed complexity-as-opt-in principle.
+- Adopted: Escalation path and TTFD analysis adopted; deployment complexity score kept as separate DX metric
+- Risks flagged: Over-correction to always-serverless
+
+### Architecture Review
+
+**lucy**: APPROVE. Synthesis faithfully represents the user's original question. Publishability preserved. One non-blocking observation: proposed margo Boring Technology addition names specific platforms where current section names none (stylistic shift).
+
+**ux-strategy-minion**: APPROVE. Journey coherence is strong. Escalation ladder transforms an invisible default into an explicit decision framework. Cognitive load reduced (triage offloaded to agent). Two observations: delegation table rows may be too granular; margo's 8/3 budget split will need calibration over time.
+
+**security-minion**: ADVISE. Three warnings: (1) iac-minion's serverless expansion omits security patterns (shared responsibility, IAM, event injection); (2) vendor lock-in framed as cost/portability only, missing security dimension (single trust point, opaque runtime); (3) escalation ladder missing security triggers (compliance forensics, mTLS, BYOK).
+
+**test-minion**: ADVISE. Two warnings: (1) Phase E verification is underspecified (narrative prose, no pass/fail criteria); (2) triage decision tree lacks calibration examples (3-5 worked scenarios would serve as implicit test cases).
+
+**margo**: ADVISE. Four concerns: (1) 5-level escalation ladder over-specified for an advisory; (2) four delegation table rows where two suffice; (3) technology maturity table reproduced out of gru's scope; (4) Phase E verification premature for non-existent changes. Core recommendations are sound and proportional.
+
+</details>
+
+## Execution
+
+### Tasks
+
+No execution tasks (advisory-only).
+
+### Files Changed
+
+No files changed (advisory-only).
+
+## Verification
+
+| Phase | Result |
+|-------|--------|
+| Code Review | Skipped (advisory-only) |
+| Test Execution | Skipped (advisory-only) |
+| Deployment | Skipped (advisory-only) |
+| Documentation | Skipped (advisory-only) |
+
+## Working Files
+
+<details>
+<summary>Working files (25 files)</summary>
+
+Companion directory: [2026-02-13-110715-serverless-bias-correction/](./2026-02-13-110715-serverless-bias-correction/)
+
+- [Original Prompt](./2026-02-13-110715-serverless-bias-correction/prompt.md)
+
+**Outputs**
+- [Phase 1: Meta-plan](./2026-02-13-110715-serverless-bias-correction/phase1-metaplan.md)
+- [Phase 2: iac-minion](./2026-02-13-110715-serverless-bias-correction/phase2-iac-minion.md)
+- [Phase 2: margo](./2026-02-13-110715-serverless-bias-correction/phase2-margo.md)
+- [Phase 2: gru](./2026-02-13-110715-serverless-bias-correction/phase2-gru.md)
+- [Phase 2: lucy](./2026-02-13-110715-serverless-bias-correction/phase2-lucy.md)
+- [Phase 2: devx-minion](./2026-02-13-110715-serverless-bias-correction/phase2-devx-minion.md)
+- [Phase 3: Synthesis](./2026-02-13-110715-serverless-bias-correction/phase3-synthesis.md)
+- [Phase 3.5: security-minion](./2026-02-13-110715-serverless-bias-correction/phase3.5-security-minion.md)
+- [Phase 3.5: test-minion](./2026-02-13-110715-serverless-bias-correction/phase3.5-test-minion.md)
+- [Phase 3.5: ux-strategy-minion](./2026-02-13-110715-serverless-bias-correction/phase3.5-ux-strategy-minion.md)
+- [Phase 3.5: lucy](./2026-02-13-110715-serverless-bias-correction/phase3.5-lucy.md)
+- [Phase 3.5: margo](./2026-02-13-110715-serverless-bias-correction/phase3.5-margo.md)
+
+**Prompts**
+- [Phase 1: Meta-plan prompt](./2026-02-13-110715-serverless-bias-correction/phase1-metaplan-prompt.md)
+- [Phase 2: iac-minion prompt](./2026-02-13-110715-serverless-bias-correction/phase2-iac-minion-prompt.md)
+- [Phase 2: margo prompt](./2026-02-13-110715-serverless-bias-correction/phase2-margo-prompt.md)
+- [Phase 2: gru prompt](./2026-02-13-110715-serverless-bias-correction/phase2-gru-prompt.md)
+- [Phase 2: lucy prompt](./2026-02-13-110715-serverless-bias-correction/phase2-lucy-prompt.md)
+- [Phase 2: devx-minion prompt](./2026-02-13-110715-serverless-bias-correction/phase2-devx-minion-prompt.md)
+- [Phase 3: Synthesis prompt](./2026-02-13-110715-serverless-bias-correction/phase3-synthesis-prompt.md)
+- [Phase 3.5: security-minion prompt](./2026-02-13-110715-serverless-bias-correction/phase3.5-security-minion-prompt.md)
+- [Phase 3.5: test-minion prompt](./2026-02-13-110715-serverless-bias-correction/phase3.5-test-minion-prompt.md)
+- [Phase 3.5: ux-strategy-minion prompt](./2026-02-13-110715-serverless-bias-correction/phase3.5-ux-strategy-minion-prompt.md)
+- [Phase 3.5: lucy prompt](./2026-02-13-110715-serverless-bias-correction/phase3.5-lucy-prompt.md)
+- [Phase 3.5: margo prompt](./2026-02-13-110715-serverless-bias-correction/phase3.5-margo-prompt.md)
+
+</details>

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase1-metaplan-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase1-metaplan-prompt.md
@@ -1,0 +1,42 @@
+MODE: META-PLAN
+
+You are creating a meta-plan -- a plan for who should help plan.
+
+## Task
+
+Advisory-only request -- no execution, no post-processing. Create a meaningful advisory report with specialist consultations on the following question:
+
+When starting greenfield projects, the system (particularly margo as YAGNI/KISS enforcer, and the general philosophy in CLAUDE.md) thinks serverless is complicated and flags it as overengineering / YAGNI / anti-KISS. But this is a wrong bias -- serverless is actually super simple (no servers to manage, no scaling config, no Docker, no Terraform for basic deployments). The question has multiple dimensions:
+
+1. **Bias correction**: Where does the anti-serverless bias live in the system? Is it in margo's heuristics? In CLAUDE.md project instructions? In the iac-minion's framing? How should it be corrected?
+2. **Entry point**: What's the right place to encode "serverless is simple, not complex" -- CLAUDE.md? Lucy's conventions? Margo's complexity budget? A combination?
+3. **Agent roster**: Should there be a dedicated serverless agent in the roster? Or should serverless knowledge be distributed across existing agents (iac-minion, edge-minion)?
+4. **Greenfield defaults**: When starting a new project with no infrastructure yet, what should the default recommendation be? Serverless-first? It depends?
+
+This is a consultation -- specialists should analyze the question from their domain perspective and make recommendations. No code will be written.
+
+## Working Directory
+/Users/ben/github/benpeter/despicable-agents
+
+## External Skill Discovery
+Before analyzing the task, scan for project-local skills. If skills are
+discovered, include an "External Skill Integration" section in your meta-plan
+(see your Core Knowledge for the output format).
+
+## Instructions
+1. Read relevant files to understand the codebase context
+2. Discover external skills:
+   a. Scan .claude/skills/ and .skills/ in the working directory for SKILL.md files
+   b. Read frontmatter (name, description) for each discovered skill
+   c. For skills whose description matches the task domain, classify as
+      ORCHESTRATION or LEAF (see External Skill Integration in your Core Knowledge)
+   d. Check the project's CLAUDE.md for explicit skill preferences
+   e. Include discovered skills in your meta-plan output
+3. Analyze the task against your delegation table
+4. Identify which specialists should be CONSULTED FOR PLANNING
+   (not execution -- planning). These are agents whose domain
+   expertise is needed to create a good plan.
+5. For each specialist, write a specific planning question that
+   draws on their unique expertise.
+6. Return the meta-plan in the structured format.
+7. Write your complete meta-plan to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase1-metaplan.md

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase1-metaplan.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase1-metaplan.md
@@ -1,0 +1,269 @@
+# Meta-Plan: Serverless Bias Correction Advisory
+
+**Mode**: META-PLAN (advisory-only -- no execution, no post-processing)
+
+## Analysis
+
+The user identifies a systemic bias in the agent system: serverless
+infrastructure is incorrectly classified as "complex" / "over-engineering"
+when it is actually simpler than the server-based alternatives for greenfield
+projects. This is an advisory consultation -- specialists analyze the question
+from their domains and produce recommendations. No code will be written.
+
+### Where the Bias Lives (Initial Assessment)
+
+After reading the relevant agent files, the bias is **not a single explicit
+statement** but rather a **structural omission combined with framing effects**:
+
+1. **iac-minion's remit and knowledge** (`the-plan.md` lines 722-748,
+   `minions/iac-minion/AGENT.md`): The entire agent is organized around
+   Terraform, Docker, Docker Compose, GitHub Actions, reverse proxies, and
+   "server deployment and operations." Serverless is mentioned nowhere in the
+   remit, nowhere in the AGENT.md knowledge base, and only once in the
+   RESEARCH.md (a passing mention of "Serverless and Managed Services" as a
+   cost optimization strategy, line 247). The iac-minion will naturally
+   recommend what it knows: VMs, containers, Terraform state management,
+   Docker multi-stage builds. For a greenfield project, this means the agent
+   will propose a Docker + Terraform + reverse proxy stack when `vercel deploy`
+   or a single Lambda function would suffice.
+
+2. **margo's complexity budget** (`margo/AGENT.md` lines 55-62): "New
+   technology: 10 points, New service: 5 points." Serverless platforms are
+   "new technology" from margo's framing, even though they are actually
+   simpler (no servers, no scaling config, no Docker, no Terraform for basic
+   deployments). The complexity budget scores infrastructure choices by their
+   novelty, not their operational burden.
+
+3. **margo's "Boring Technology" heuristic** (`margo/AGENT.md` lines 171-179):
+   "Choose boring technology. Boring tech has decades of production hardening."
+   This frames Terraform + Docker + Nginx as "boring" (decades old) and
+   serverless as "new" (innovation token spend). But AWS Lambda is 12 years old,
+   Vercel has been production-ready since 2020, and Cloudflare Workers since
+   2018. Serverless IS boring technology now.
+
+4. **The absence in the delegation table** (`the-plan.md` lines 297-358):
+   There is no "serverless deployment" row. "Infrastructure provisioning"
+   routes to iac-minion, which means serverless is handled by an agent whose
+   entire knowledge base is server-centric.
+
+5. **edge-minion knows some serverless** (`minions/edge-minion/AGENT.md`):
+   Cloudflare Workers, D1, KV, R2, Durable Objects -- but scoped to CDN/edge
+   compute, not general serverless deployment. The edge-minion would not
+   naturally be consulted for "deploy a new API" even if Workers would be the
+   simplest path.
+
+6. **data-minion has serverless database knowledge** (`minions/data-minion/AGENT.md`
+   lines 172-174): Neon serverless PostgreSQL, Turso. But this is scoped to
+   database selection, not deployment strategy.
+
+7. **No CLAUDE.md anti-serverless directive**: The project CLAUDE.md and user
+   CLAUDE.md do not mention serverless at all -- the bias is entirely emergent
+   from agent knowledge gaps and heuristic framing, not from an explicit rule.
+
+### The Four Questions
+
+1. **Bias correction**: The bias is distributed across (a) iac-minion's knowledge
+   gap, (b) margo's heuristic framing, (c) absence in the delegation table.
+2. **Entry point**: Multiple touch points needed -- no single fix suffices.
+3. **Agent roster**: Needs analysis -- dedicated agent vs. distributed knowledge.
+4. **Greenfield defaults**: Needs specialist input on what "simple" means per
+   domain.
+
+## Planning Consultations
+
+### Consultation 1: Infrastructure Simplicity Assessment
+
+- **Agent**: iac-minion
+- **Planning question**: You are being asked to critically assess your own
+  knowledge base. Your current remit covers Terraform, Docker, GitHub Actions,
+  reverse proxies, and cloud provider patterns. Serverless platforms (AWS Lambda,
+  Cloudflare Workers, Vercel, Netlify, Deno Deploy, Cloudflare Pages) are absent
+  from your knowledge. For a greenfield project that needs a simple API or a
+  static site with a few server functions, compare the operational complexity of:
+  (a) your current default stack (Terraform + Docker + reverse proxy + server),
+  and (b) a serverless deployment (e.g., `vercel deploy` or a single Lambda).
+  What serverless knowledge should be added to your remit? What should remain
+  outside your scope? Should serverless be your default recommendation for
+  greenfield, with server infrastructure as the escalation path when serverless
+  constraints are hit?
+- **Context to provide**: Current iac-minion AGENT.md, the-plan.md spec for
+  iac-minion (lines 722-748), the user's observation that serverless is simpler
+  than the current default stack for most greenfield projects.
+- **Why this agent**: The iac-minion is the primary agent affected by the bias.
+  It needs to self-assess where serverless fits in its remit and where the
+  complexity boundaries actually lie.
+
+### Consultation 2: Complexity Budget Recalibration
+
+- **Agent**: margo
+- **Planning question**: Your complexity budget assigns "New technology: 10 points"
+  and "New service: 5 points." Your "Boring Technology" heuristic frames decade-old
+  tech as safe and newer tech as innovation-token spends. But serverless platforms
+  (AWS Lambda launched 2014, Vercel production since 2020, Cloudflare Workers
+  since 2018) are now boring technology by any reasonable measure. Meanwhile,
+  Terraform state management, Docker layer optimization, and reverse proxy
+  configuration are all accidental complexity that serverless eliminates entirely.
+  How should your complexity budget and "boring technology" heuristic be updated
+  to correctly account for the fact that serverless is often simpler, not more
+  complex? Specifically: (a) Should "serverless deployment" score LOWER than
+  "server + container + orchestration" on your complexity budget? (b) Should the
+  "boring technology" heuristic include serverless platforms as boring? (c) What
+  signals should trigger margo to flag server infrastructure as over-engineering
+  when serverless would suffice?
+- **Context to provide**: Current margo AGENT.md complexity budget section,
+  boring technology section, the user's framing of the problem.
+- **Why this agent**: Margo is the YAGNI/KISS enforcer. If margo's heuristics
+  incorrectly penalize serverless, the entire system inherits that bias. Margo
+  needs to recalibrate.
+
+### Consultation 3: Technology Radar Assessment of Serverless Maturity
+
+- **Agent**: gru
+- **Planning question**: Using your adopt/trial/assess/hold framework, classify
+  the following serverless platforms: AWS Lambda, Cloudflare Workers/Pages,
+  Vercel, Netlify, Deno Deploy. For each, assess: production maturity, community
+  velocity, failure mode documentation, vendor lock-in risk, and cost model
+  predictability. The goal is to establish whether serverless is legitimately
+  "boring technology" that should be a default recommendation for greenfield
+  projects, or whether it still carries enough risk to warrant case-by-case
+  assessment. Also: should the despicable-agents roster include a dedicated
+  serverless agent, or should serverless knowledge be distributed across
+  iac-minion and edge-minion?
+- **Context to provide**: gru's adopt/trial/assess/hold framework, the user's
+  observation that serverless is being incorrectly treated as complex, the
+  current agent roster structure.
+- **Why this agent**: Gru's role is strategic technology assessment. The question
+  of whether serverless is "adopt" or "trial" directly determines how it should
+  be treated in the system's defaults.
+
+### Consultation 4: Convention and Entry Point Design
+
+- **Agent**: lucy
+- **Planning question**: If we want to encode "serverless-first for greenfield
+  projects" as a system-level default, where should this convention live?
+  Options: (a) project CLAUDE.md as a technology preference, (b) margo's
+  heuristics as a complexity calibration, (c) iac-minion's working patterns
+  as a "start here" default, (d) the delegation table in the-plan.md as a new
+  routing row, (e) a combination. From your perspective as convention enforcer,
+  which encoding is most enforceable, least likely to drift, and most discoverable
+  by agents during planning? Consider the resolution hierarchy (CLAUDE.md vs
+  agent knowledge vs delegation table) and where a "greenfield defaults" directive
+  would have the most consistent effect.
+- **Context to provide**: The CLAUDE.md hierarchy, the-plan.md delegation table
+  structure, lucy's convention enforcement process.
+- **Why this agent**: Lucy enforces conventions and CLAUDE.md compliance. The
+  question of WHERE to encode serverless-first is a convention design question --
+  lucy's core domain.
+
+### Consultation 5: Developer Experience for Serverless Defaults
+
+- **Agent**: devx-minion
+- **Planning question**: From a developer experience perspective, what does a
+  good "serverless-first greenfield" experience look like? When a developer
+  starts a new project, what should the default deployment path be? What are the
+  common serverless DX pain points (cold starts, local development, debugging,
+  vendor lock-in, cost surprises at scale) and how should the agent system
+  help developers navigate them? Should the system have a "complexity escalation
+  path" -- start serverless, move to containers when you hit limits -- and if so,
+  what are the trigger signals for escalation?
+- **Context to provide**: The user's observation that `vercel deploy` is simpler
+  than Docker + Terraform, the current iac-minion remit.
+- **Why this agent**: DevX-minion specializes in developer onboarding and the
+  experience of using tools. The serverless-first question is fundamentally about
+  what the simplest developer path should be.
+
+## Cross-Cutting Checklist
+
+- **Testing**: Not included for planning. No code will be written. Test
+  implications of serverless (e.g., testing Lambda functions locally) are within
+  scope of the advisory but do not require test-minion consultation at the
+  planning phase.
+- **Security**: Not included for planning. Security implications of serverless
+  (shared responsibility model, function-level permissions) are relevant but this
+  is an advisory about system bias, not a security review. If recommendations
+  lead to agent changes, security review would apply at that point.
+- **Usability -- Strategy**: Included via devx-minion (Consultation 5). The
+  "developer as user" perspective is the relevant UX lens here -- the question
+  is about what the simplest developer experience should be. ux-strategy-minion
+  is not needed because this advisory is about infrastructure defaults, not
+  end-user journeys.
+- **Usability -- Design**: Not applicable. No UI is being designed.
+- **Documentation**: Not included for planning. If the advisory leads to agent
+  changes, documentation would follow. software-docs-minion would be relevant
+  at execution time, not advisory time.
+- **Observability**: Not applicable to this advisory. Observability implications
+  of serverless (structured logging in Lambda, distributed tracing across
+  functions) are within scope of the advisory discussion but do not require
+  dedicated observability-minion consultation at planning.
+
+### Justification for Checklist Exclusions
+
+This is an advisory-only consultation -- no code, no infrastructure, no
+user-facing changes. The cross-cutting concerns (testing, security,
+observability, documentation) are relevant to the TOPIC being discussed
+(serverless) but not to the ACTIVITY being performed (analysis and
+recommendations). Including these agents in an advisory would be scope creep
+by margo's own standards. If the advisory produces actionable recommendations
+that lead to agent changes, those changes would go through the full nefario
+process including all cross-cutting reviews.
+
+ux-strategy-minion is partially covered via devx-minion's developer experience
+consultation, which addresses the "user journey" dimension for the relevant
+user persona (developers choosing infrastructure).
+
+## Anticipated Approval Gates
+
+None. This is an advisory consultation -- no execution plan, no deliverables
+requiring approval. The output is a report of specialist recommendations that
+the user can act on (or not) at their discretion.
+
+## Rationale
+
+Five specialists were chosen because the question has five distinct dimensions:
+
+1. **iac-minion** -- the agent most directly affected by the bias. Its knowledge
+   gap IS the bias for deployment recommendations.
+2. **margo** -- the agent whose heuristics amplify the bias. Complexity budget
+   and boring-tech scoring need recalibration.
+3. **gru** -- provides the objective technology maturity assessment that grounds
+   the entire discussion. Is serverless boring or not?
+4. **lucy** -- answers the "where to encode it" question, which is a convention
+   design problem.
+5. **devx-minion** -- provides the developer experience perspective that
+   contextualizes what "simple" actually means in practice.
+
+Agents NOT included and why:
+- **edge-minion**: Already has some serverless knowledge (Workers). Could
+  contribute, but the consultation would overlap heavily with iac-minion's
+  self-assessment. If gru recommends distributing serverless knowledge,
+  edge-minion's role will be addressed in gru's response.
+- **data-minion**: Already has serverless database knowledge. Not directly
+  relevant to the deployment bias question.
+- **security-minion**: Serverless security model is important but orthogonal
+  to the bias correction question. Would be consulted if this leads to
+  execution.
+
+## Scope
+
+**In scope**: Analysis of where anti-serverless bias lives in the agent system,
+recommendations for correcting it, assessment of serverless maturity,
+recommendation on agent roster changes, guidance on greenfield defaults.
+
+**Out of scope**: Writing code, modifying agent files, modifying the-plan.md,
+modifying CLAUDE.md, creating new agents, executing any changes. This is purely
+advisory.
+
+## External Skill Integration
+
+### Discovered Skills
+
+| Skill | Location | Classification | Domain | Recommendation |
+|-------|----------|---------------|--------|----------------|
+| despicable-lab | `.claude/skills/despicable-lab/` | LEAF | Agent build/rebuild | Not relevant to this advisory |
+| despicable-statusline | `.claude/skills/despicable-statusline/` | LEAF | UI configuration | Not relevant to this advisory |
+
+No user-global skills discovered that overlap with this task domain.
+
+### Precedence Decisions
+
+No conflicts -- neither discovered skill overlaps with the advisory domain.

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-devx-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-devx-minion-prompt.md
@@ -1,0 +1,48 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet -- you are providing your domain expertise
+to help build a comprehensive plan.
+
+## Project Task
+
+Advisory-only consultation: The despicable-agents system has a structural bias against serverless infrastructure. We need to understand the developer experience perspective -- what does a good serverless-first greenfield experience look like, and how should the agent system guide developers through it?
+
+## Your Planning Question
+
+From a developer experience perspective, what does a good "serverless-first greenfield" experience look like? When a developer starts a new project, what should the default deployment path be? What are the common serverless DX pain points (cold starts, local development, debugging, vendor lock-in, cost surprises at scale) and how should the agent system help developers navigate them?
+
+Should the system have a "complexity escalation path" -- start serverless, move to containers when you hit limits -- and if so, what are the trigger signals for escalation? Think about:
+- Time-to-first-deploy: `vercel deploy` vs Docker + Terraform
+- Local development: how do you test serverless functions locally?
+- Debugging: how do you debug in production?
+- The "escape hatch": when serverless stops working, what's the graceful migration path?
+- CLI/SDK design: what should a good serverless CLI experience look like?
+
+## Context
+
+Read the following files:
+- /Users/ben/github/benpeter/despicable-agents/minions/devx-minion/AGENT.md (your current spec)
+- /Users/ben/github/benpeter/despicable-agents/minions/iac-minion/AGENT.md (current default infra agent)
+
+The user's core observation: `vercel deploy` is 1 command with zero infrastructure management. Docker + Terraform + Caddy is dozens of configuration files. The simplest path should be the default path.
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. Return your contribution in this format:
+
+## Domain Plan Contribution: devx-minion
+
+### Recommendations
+<your expert recommendations>
+
+### Proposed Tasks
+<specific tasks>
+
+### Risks and Concerns
+<things that could go wrong>
+
+### Additional Agents Needed
+<or "None">
+
+5. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase2-devx-minion.md

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-devx-minion.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-devx-minion.md
@@ -1,0 +1,412 @@
+# Phase 2 Contribution: devx-minion
+
+## Domain Perspective: Developer Experience for Serverless-First Greenfield
+
+### Executive Summary
+
+The current agent system's default deployment path is hostile to the most common
+developer journey: "I have code, I want it running on the internet." The iac-minion's
+knowledge base assumes the developer has already decided to manage servers, and
+then helps them do it well. But the prior question -- "should you manage servers
+at all?" -- is never asked. From a DX perspective, this is the most damaging gap
+in the system. The default path should be the simplest path. For most greenfield
+projects, the simplest path is serverless.
+
+---
+
+### 1. What a Good "Serverless-First Greenfield" Experience Looks Like
+
+**The gold standard is zero-to-deployed in under 5 minutes.** The developer experience
+benchmark is:
+
+```
+# The entire deployment journey for a greenfield project
+npm create next-app my-api
+cd my-api
+vercel deploy
+# Live URL in 47 seconds
+```
+
+Compare with the current iac-minion default path:
+
+```
+# Step 1: Write the application (same)
+# Step 2: Containerize it
+#   - Write Dockerfile (multi-stage build, base image selection)
+#   - Write .dockerignore
+#   - Test build locally
+# Step 3: Provision infrastructure
+#   - Write Terraform HCL (provider, VPC, security groups, instance)
+#   - Configure remote state backend (S3 + DynamoDB for locking)
+#   - terraform init && terraform plan && terraform apply
+# Step 4: Configure the server
+#   - Write Caddyfile or nginx.conf for reverse proxy
+#   - Configure SSL/TLS
+#   - Set up systemd service or docker-compose
+# Step 5: Deploy
+#   - Push image to registry
+#   - SSH or run deployment script
+#   - Verify health checks
+# Total: 30-120 minutes for someone experienced, days for a beginner
+```
+
+The ratio is roughly **50:1 in time-to-first-deploy.** This is not a minor
+difference -- it is a category difference. The iac-minion's default path has the
+developer writing infrastructure code before their application code is running
+anywhere. That is backwards.
+
+**A good serverless-first greenfield experience has these properties:**
+
+1. **Zero infrastructure configuration for the first deploy.** No Terraform, no
+   Docker, no reverse proxy. The platform handles compute, TLS, DNS, scaling.
+2. **Git-push-to-deploy as the default CI/CD.** No GitHub Actions workflow files
+   needed for basic deployment. Push to main, it deploys.
+3. **Local development that matches production.** `dev` command starts a local
+   server that behaves like the deployed version. No Docker required locally.
+4. **Preview deployments for every PR.** Automatic, no configuration. Every pull
+   request gets a unique URL.
+5. **Environment variables as the only configuration surface.** No YAML, no TOML,
+   no HCL. Just key-value pairs in a dashboard or CLI.
+6. **Instant rollback.** Every deployment is immutable. Rolling back is selecting
+   a previous deployment, not re-running a pipeline.
+
+### 2. The Default Deployment Path: A Decision Tree
+
+The agent system should guide developers through a decision tree, not start them
+on the most complex path. Here is the tree I recommend, ordered by increasing
+complexity:
+
+**Level 0: Static site (no server logic)**
+- Path: Cloudflare Pages, Vercel, Netlify, GitHub Pages
+- Time to deploy: < 2 minutes
+- Configuration: zero
+- Trigger: project has only HTML/CSS/JS, or uses a static site generator
+
+**Level 1: Static site + API routes / edge functions**
+- Path: Vercel (API routes), Cloudflare Workers/Pages Functions, Netlify Functions
+- Time to deploy: < 5 minutes
+- Configuration: project structure convention (e.g., `/api` directory)
+- Trigger: project needs server logic but individual functions, not a long-running server
+
+**Level 2: Full application with serverless backend**
+- Path: Vercel (Next.js/SvelteKit/etc.), Cloudflare Workers (full app), AWS Lambda + API Gateway
+- Time to deploy: 5-15 minutes
+- Configuration: framework config + environment variables
+- Trigger: project is a full web application with SSR, API, database
+
+**Level 3: Containerized application (serverless containers)**
+- Path: AWS Fargate, Google Cloud Run, Fly.io, Railway
+- Time to deploy: 15-30 minutes
+- Configuration: Dockerfile + platform config
+- Trigger: application needs long-running processes, WebSockets beyond platform limits,
+  custom runtimes, binary dependencies not available in serverless runtimes
+
+**Level 4: Self-managed infrastructure**
+- Path: Docker + Terraform + reverse proxy (current iac-minion default)
+- Time to deploy: 1-4 hours
+- Configuration: Dockerfile + Terraform HCL + Caddyfile + CI/CD pipeline
+- Trigger: specific compliance requirements (data residency, dedicated tenancy),
+  cost optimization at scale (> $5k/month cloud bill), custom networking requirements,
+  bare-metal performance needs
+
+**The current system starts developers at Level 4.** It should start them at
+Level 0-1 and escalate only when constraints demand it.
+
+### 3. Common Serverless DX Pain Points and Agent Mitigations
+
+#### 3.1 Cold Starts
+
+**The pain:** First invocation after idle period takes 500ms-5s depending on
+runtime and bundle size. Developers see this in development, panic, and
+over-engineer warm-keeping solutions.
+
+**How the agent system should help:**
+- Quantify the impact: "Cold starts affect < 1% of requests for APIs with
+  steady traffic. For 99th percentile latency-sensitive APIs, consider
+  provisioned concurrency."
+- Platform-specific guidance: Cloudflare Workers have near-zero cold starts
+  (V8 isolates, not containers). AWS Lambda cold starts vary by runtime
+  (Node.js ~200ms, Java ~2-5s). Vercel edge functions use V8 isolates.
+- Decision heuristic: "If your p99 latency budget is > 500ms, cold starts
+  are not a real problem. If your p99 budget is < 100ms, use edge functions
+  (Cloudflare Workers, Vercel Edge) or provisioned concurrency."
+- Anti-pattern detection: flag developers who add "keep-warm" cron jobs as
+  over-engineering when their traffic is sufficient for natural warm-keeping.
+
+#### 3.2 Local Development
+
+**The pain:** "How do I test my serverless functions locally?" is the #1 question
+for serverless beginners. The gap between local development and production is
+the single biggest DX failure of first-generation serverless (raw Lambda without
+frameworks).
+
+**How the agent system should help:**
+- Recommend frameworks with local dev parity:
+  - Vercel: `vercel dev` runs locally with the same routing and function execution
+  - Cloudflare: `wrangler dev` provides local Workers runtime with KV, D1, R2 bindings
+  - Netlify: `netlify dev` proxies functions locally
+  - SST (for AWS): `sst dev` provides live Lambda debugging with breakpoints
+  - AWS SAM: `sam local start-api` for local API Gateway + Lambda emulation
+- Anti-pattern: never recommend "deploy to test." Local development must work.
+- Framework selection guidance: "Choose a framework that provides a local dev
+  server that matches production behavior. If the framework does not have `dev`
+  command parity, it is not ready for production use."
+
+#### 3.3 Debugging in Production
+
+**The pain:** No SSH, no `docker exec`, no attaching a debugger to a running
+process. Serverless functions are ephemeral. When something goes wrong in
+production, developers feel blind.
+
+**How the agent system should help:**
+- Structured logging as the primary debugging tool. Every serverless function
+  should emit structured JSON logs with correlation IDs, request context, and
+  timing information.
+- Platform-native observability:
+  - Vercel: built-in logs, serverless function traces, Edge Runtime logs
+  - Cloudflare: Workers Logpush, Tail Workers for real-time log streaming
+  - AWS: CloudWatch Logs with structured queries, X-Ray for tracing
+- Error tracking integration: recommend Sentry, Axiom, or Baselime (now
+  part of Cloudflare) for serverless-specific error tracking with source maps.
+- The agent system should proactively recommend: "Add structured logging and
+  error tracking BEFORE your first production deployment, not after your first
+  production incident."
+
+#### 3.4 Vendor Lock-in
+
+**The pain:** "If I build on Vercel, am I stuck on Vercel?" This fear causes
+developers to over-abstract their deployment layer, adding complexity to solve
+a problem they do not yet have.
+
+**How the agent system should help:**
+- Quantify the actual lock-in surface. For most serverless platforms, the
+  lock-in is in platform-specific APIs (Vercel KV, Cloudflare KV, AWS DynamoDB),
+  not in the compute layer. A Next.js app can move from Vercel to self-hosted
+  with moderate effort. An Express API can move from Lambda to any container.
+- Recommend standard interfaces: use standard Node.js HTTP (Request/Response),
+  standard SQL databases (PostgreSQL via Neon/Supabase), standard object storage
+  (S3-compatible APIs). The function code itself is usually portable.
+- Decision heuristic: "Vendor lock-in becomes a real concern when your monthly
+  bill exceeds $5k or when you need capabilities the platform does not offer.
+  Below that threshold, optimize for speed, not portability."
+- Anti-pattern detection: flag developers who add Terraform + Docker + Kubernetes
+  "just in case we need to move" as premature abstraction. YAGNI applies to
+  infrastructure portability too.
+
+#### 3.5 Cost Surprises at Scale
+
+**The pain:** Serverless pricing is per-invocation. At low scale, it is free
+or nearly free. At high scale, it can be dramatically more expensive than a
+fixed-cost server.
+
+**How the agent system should help:**
+- Provide cost comparison heuristics:
+  - Rule of thumb: serverless is cheaper below ~1M requests/month for typical
+    API workloads. Above that, compare carefully.
+  - Vercel: generous free tier, Pro at $20/month covers most small-medium projects
+  - Cloudflare Workers: 100k requests/day free, $5/month for 10M requests
+  - AWS Lambda: 1M free requests/month, then $0.20 per 1M
+  - Break-even point vs. a $5/month Hetzner VPS: roughly 5-10M requests/month
+    depending on function duration
+- Proactive cost monitoring: "Set up cost alerts at 50%, 80%, and 100% of
+  your expected monthly budget. Serverless costs are linear with traffic --
+  viral posts or bot attacks can cause bill shock."
+- Escalation trigger: "When your serverless bill consistently exceeds $500/month
+  for a single service, evaluate whether a container (Fly.io, Cloud Run) or
+  dedicated server would be more cost-effective. This is the Level 2 -> Level 3
+  transition."
+
+### 4. The Complexity Escalation Path
+
+Yes, the system absolutely should have a complexity escalation path. The metaphor
+is: **start on the elevator, take the stairs only when you outgrow the building.**
+
+#### Escalation Triggers (When to Move Up a Level)
+
+| Signal | Current Level | Escalation To | Rationale |
+|--------|--------------|---------------|-----------|
+| Need WebSocket connections beyond platform limits | Level 1-2 | Level 3 (containers) | Most serverless platforms limit WebSocket duration |
+| Function execution > 30s consistently | Level 1-2 | Level 3 (containers) | Serverless timeout limits (Vercel 30s/300s, Lambda 15min) |
+| Monthly bill > $500/service | Level 2 | Level 3 (containers) | Cost optimization threshold |
+| Need custom binary dependencies or OS-level packages | Level 2 | Level 3 (containers) | Serverless runtimes have limited system access |
+| Data residency / compliance requirements | Level 2-3 | Level 4 (self-managed) | Need to control physical infrastructure location |
+| Monthly bill > $5k/service | Level 3 | Level 4 (self-managed) | Significant cost savings from dedicated infrastructure |
+| Need bare-metal performance (GPU, specific CPU) | Any | Level 4 | Serverless cannot provide hardware-specific compute |
+| Multi-region active-active with custom routing | Level 2-3 | Level 3-4 | Complex routing beyond platform capabilities |
+
+#### De-escalation Triggers (When to Move Down)
+
+This is equally important and almost never discussed. The agent system should
+also recognize when infrastructure is over-provisioned:
+
+| Signal | Current Level | De-escalation To | Rationale |
+|--------|--------------|------------------|-----------|
+| Server utilization consistently < 10% | Level 4 | Level 3 or 2 | Paying for idle capacity |
+| Ops burden dominates development time | Level 4 | Level 3 | Infrastructure maintenance is not value-add |
+| Scaling events cause incidents | Level 4 | Level 2-3 | Serverless auto-scales; your manual scaling does not |
+| Team < 3 developers managing infrastructure | Level 4 | Level 2-3 | Small teams should not carry infra overhead |
+| Docker/Terraform config larger than application code | Level 4 | Level 2-3 | Infrastructure complexity exceeds application complexity |
+
+### 5. CLI/SDK Design for Serverless Deployment
+
+A good serverless CLI experience follows these principles:
+
+**5.1 Single-command deploy:**
+```
+myapp deploy           # Deploy current directory to production
+myapp deploy --preview # Deploy a preview environment
+myapp deploy --env staging
+```
+
+Not:
+```
+docker build -t myapp .
+docker push registry/myapp:latest
+terraform -chdir=infra plan
+terraform -chdir=infra apply -auto-approve
+ssh server 'docker pull registry/myapp:latest && docker-compose up -d'
+```
+
+**5.2 Progressive disclosure in the CLI:**
+- `deploy` is the only command a beginner needs
+- `config`, `env`, `logs`, `domains` are discovered when needed
+- `rollback` is available but not required
+- Infrastructure details (regions, scaling, runtime) are flags on `deploy`,
+  not separate commands
+
+**5.3 Error messages that guide escalation:**
+```
+Error: Function execution timed out after 30 seconds.
+
+Your function exceeded the serverless execution limit. Options:
+  1. Optimize the function to complete faster (most common fix)
+  2. Increase timeout: vercel.json -> { "functions": { "maxDuration": 300 } }
+  3. If this function inherently needs long execution, consider moving to a
+     container runtime: https://docs.example.com/guides/migrate-to-containers
+
+Run `myapp logs --function api/process` to see execution traces.
+```
+
+This error message does three things: explains the constraint, offers a
+quick fix, and provides the escalation path. It does not just say "timeout."
+
+**5.4 What the agent system should produce for serverless projects:**
+- `vercel.json` or `wrangler.toml` instead of `Dockerfile + docker-compose.yml + Caddyfile + terraform/*.tf`
+- GitHub Actions for CI (lint, test) but NOT for CD (the platform handles deploy)
+- Environment variable configuration guidance instead of secrets management infrastructure
+- A single deployment command in the README instead of a multi-step deployment guide
+
+### 6. Recommendations for the Agent System
+
+#### 6.1 iac-minion Must Add a "Deployment Strategy Selection" Step
+
+Before recommending any specific infrastructure, iac-minion should ask:
+"What is the simplest deployment path for this workload?" The answer should
+be determined by the decision tree in Section 2, not by defaulting to the
+most capable (and most complex) option.
+
+Specifically, iac-minion's Working Patterns should start with:
+
+> **When Designing Deployment Infrastructure:**
+> 1. Start with the simplest deployment path (Level 0-2: platform-managed serverless)
+> 2. Only escalate to containers (Level 3) or self-managed (Level 4) when a
+>    specific constraint demands it
+> 3. Document which constraint triggered the escalation
+> 4. If no constraint is identified, the answer is serverless
+
+#### 6.2 The Delegation Table Needs a "Deployment strategy" Row
+
+The current delegation table routes "Infrastructure provisioning" to iac-minion.
+But "infrastructure provisioning" implies there IS infrastructure to provision.
+For serverless deployments, there is no infrastructure -- just platform configuration.
+
+Proposed addition to the delegation table:
+
+| Task Type | Primary | Supporting |
+|-----------|---------|------------|
+| Deployment strategy selection | iac-minion | devx-minion, edge-minion |
+| Serverless deployment config | edge-minion | iac-minion |
+| Container deployment | iac-minion | edge-minion |
+| Self-managed infrastructure | iac-minion | security-minion |
+
+This separates "deciding HOW to deploy" from "provisioning infrastructure,"
+and routes serverless deployment config to edge-minion (who already knows
+Cloudflare Workers, Vercel edge, etc.) with iac-minion as supporting.
+
+#### 6.3 devx-minion Should Own "Time-to-First-Deploy" as a Metric
+
+The devx-minion currently tracks "time to first deployment" as a metric but
+does not have guidance on what that metric should look like for different
+deployment paths. I recommend adding to the devx-minion knowledge base:
+
+- **Deployment DX benchmarks**: Level 0-1 should be < 5 min, Level 2 < 15 min,
+  Level 3 < 30 min, Level 4 < 4 hours
+- **Deployment complexity scoring**: count of configuration files, count of
+  CLI commands, count of external service accounts needed
+- **Serverless local dev parity checklist**: does the local `dev` command
+  match production routing, function execution, environment variable injection,
+  and database access?
+
+#### 6.4 margo's Complexity Budget Should Score Deployment Paths
+
+Margo should have a deployment complexity score that counts actual operational
+burden, not perceived novelty:
+
+| Deployment Path | Config Files | External Services | Ongoing Ops | Score |
+|----------------|-------------|------------------|-------------|-------|
+| Vercel / CF Pages | 0-1 | 1 (platform) | None | 1 |
+| Serverless + DB | 1-2 | 2 (platform + DB) | None | 3 |
+| Container (Fly/CR) | 2-3 | 2-3 | Minimal | 5 |
+| Docker + Terraform | 5-10 | 3-5 | Significant | 12 |
+| Kubernetes | 10-20 | 5-10 | Major | 25 |
+
+Under this scoring, recommending Docker + Terraform for a project that could
+run on Vercel is a **complexity escalation of 12x** -- which is exactly the
+kind of over-engineering margo is designed to catch.
+
+### 7. Risks and Dependencies
+
+**Risks:**
+1. **Platform-specific knowledge fragmentation.** If serverless knowledge is
+   distributed across iac-minion and edge-minion, neither may have sufficient
+   depth. The agent consulted depends on how the user phrases their request --
+   "deploy my app" goes to iac-minion (who knows Docker), not edge-minion
+   (who knows Cloudflare Workers).
+2. **Stale platform knowledge.** Serverless platforms evolve rapidly. Vercel's
+   capabilities in 2026 are different from 2024. The agent knowledge base needs
+   a refresh mechanism for platform-specific guidance.
+3. **Over-correction risk.** The fix for "always recommends servers" should not
+   be "always recommends serverless." The decision tree must genuinely evaluate
+   constraints, not just flip the default. Some workloads genuinely need Level 3-4.
+4. **Local development tooling variance.** The quality of local dev experience
+   varies dramatically between platforms. `wrangler dev` is excellent.
+   `sam local` is mediocre. This affects which platforms the system should
+   recommend.
+
+**Dependencies:**
+1. iac-minion's remit update (Section 6.1) depends on margo accepting the
+   complexity recalibration (Section 6.4), otherwise margo will flag serverless
+   recommendations as "new technology" penalty.
+2. Delegation table changes (Section 6.2) require coordination with the
+   the-plan.md spec and all agents that reference "infrastructure provisioning."
+3. edge-minion may need expanded scope if it becomes the primary agent for
+   serverless deployment (currently scoped to CDN/edge, not general deployment).
+
+### 8. Additional Agents Recommended
+
+No additional agents needed for this advisory beyond those already in the
+meta-plan. However, if the recommendations lead to execution:
+- **edge-minion** should be consulted on its willingness/readiness to take on
+  "serverless deployment config" as a primary responsibility.
+- **test-minion** should be consulted on serverless testing patterns (local
+  emulation, integration testing against deployed previews).
+
+### 9. Key Insight
+
+The fundamental DX principle at stake: **complexity should be opt-in, not
+opt-out.** The current system requires developers to opt out of server management
+(by knowing enough to ask for serverless). It should require developers to opt
+in to server management (by hitting a constraint that demands it). This is the
+same principle as "sensible defaults, progressive complexity" that already
+governs the devx-minion's approach to SDK and CLI design. It just needs to be
+extended to deployment strategy.

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-gru-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-gru-prompt.md
@@ -1,0 +1,50 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet -- you are providing your domain expertise
+to help build a comprehensive plan.
+
+## Project Task
+
+Advisory-only consultation: The despicable-agents system has a structural bias against serverless infrastructure. When the system encounters greenfield projects, it tends to recommend server-based stacks over serverless. We need an objective technology maturity assessment to determine whether serverless is legitimately "boring technology" that should be a default recommendation.
+
+## Your Planning Question
+
+Using your adopt/trial/assess/hold framework, classify the following serverless platforms: AWS Lambda, Cloudflare Workers/Pages, Vercel, Netlify, Deno Deploy. For each, assess:
+- Production maturity
+- Community velocity
+- Failure mode documentation
+- Vendor lock-in risk
+- Cost model predictability
+
+The goal is to establish whether serverless is legitimately "boring technology" that should be a default recommendation for greenfield projects, or whether it still carries enough risk to warrant case-by-case assessment.
+
+Also: should the despicable-agents roster include a dedicated serverless agent, or should serverless knowledge be distributed across iac-minion and edge-minion?
+
+## Context
+
+Read the following files:
+- /Users/ben/github/benpeter/despicable-agents/gru/AGENT.md (your assessment framework)
+- /Users/ben/github/benpeter/despicable-agents/the-plan.md (lines 81-120 for your spec, lines 722-784 for iac-minion and edge-minion specs)
+
+The agent system currently has 27 agents. The question is whether serverless warrants a 28th, or whether existing agents can absorb it.
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. Return your contribution in this format:
+
+## Domain Plan Contribution: gru
+
+### Recommendations
+<your expert recommendations>
+
+### Proposed Tasks
+<specific tasks>
+
+### Risks and Concerns
+<things that could go wrong>
+
+### Additional Agents Needed
+<or "None">
+
+5. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase2-gru.md

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-gru.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-gru.md
@@ -1,0 +1,265 @@
+# Phase 2: Gru -- Serverless Technology Maturity Assessment
+
+## TL;DR
+
+Serverless is not a single technology; it is a deployment model with a maturity
+spectrum. AWS Lambda is unambiguously "boring technology" -- Adopt ring, 10+
+years of production, well-documented failure modes, predictable-enough cost
+model. Cloudflare Workers is close behind at Adopt for edge-native workloads.
+Vercel and Netlify are Trial for frontend-first projects (strong DX, cost
+unpredictability at scale). Deno Deploy is Assess (promising, insufficient
+production signals). The despicable-agents system has a legitimate structural
+bias: iac-minion defaults to servers+containers and edge-minion covers CDN
+compute, but neither owns the "serverless as default deployment target for
+greenfield" decision. This is a knowledge gap, not an agent gap. Fix it by
+expanding iac-minion's remit, not by adding a 28th agent.
+
+---
+
+## Platform-by-Platform Assessment
+
+### 1. AWS Lambda -- ADOPT
+
+| Dimension | Assessment |
+|-----------|------------|
+| **Production maturity** | 10+ years (launched 2014). BMW processes 16.6B requests/day. Netflix, Coca-Cola, Capital One in production at scale. This is the most battle-tested serverless platform in existence. |
+| **Community velocity** | Massive ecosystem. SAM, Serverless Framework, CDK, Terraform all have mature Lambda support. AWS re:Invent 2025 shipped Lambda Managed Instances and Durable Functions -- meaningful evolution, not hype. |
+| **Failure mode documentation** | Excellent. Cold starts are the most-studied failure mode in cloud computing. VPC cold starts (now ~100ms), INIT phase billing (Aug 2025), infinite-loop cost disasters, connection exhaustion under burst -- all extensively documented with mitigations. |
+| **Vendor lock-in risk** | HIGH. Lambda functions use AWS-proprietary event model, IAM integration, and service triggers (SQS, DynamoDB Streams, API Gateway). Migration cost estimated at $1.2M per org (industry survey). Mitigation: keep business logic in portable libraries, use Lambda as a thin invocation layer. |
+| **Cost model predictability** | MEDIUM. Pay-per-invocation is predictable at steady state. Dangerous at extremes: infinite loops, burst traffic, and the Aug 2025 INIT phase billing change (10-50% cost increase for cold-start-heavy workloads). Requires cost monitoring tooling (AWS Cost Explorer, third-party). Real-world billing disasters are well-documented ($12K misconfigured function, $50K infinite loop). |
+
+**Hype filter results:**
+1. Production usage: abundant, verified, multi-industry (6/6)
+2. Community velocity: massive contributor ecosystem, mature tooling (6/6)
+3. Second-order signals: Lambda skills in every DevOps job posting (6/6)
+4. Failure stories: extensively documented -- this is a mature technology (6/6)
+5. Benchmark independence: third-party benchmarks exist (Datadog State of Serverless, etc.) (5/6)
+6. Revenue signal: customers paying full price, no VC subsidy (6/6)
+
+**Verdict: Adopt now.** AWS Lambda meets every criterion for boring technology.
+The team should treat Lambda the way it treats PostgreSQL -- default to it for
+event-driven and API workloads unless a specific requirement disqualifies it.
+
+---
+
+### 2. Cloudflare Workers / Pages -- ADOPT (for edge-native workloads)
+
+| Dimension | Assessment |
+|-----------|------------|
+| **Production maturity** | 7+ years (Workers launched 2017). Cloudflare Q4 2025 revenue beat estimates. Enterprise growth accelerating. Production-ready for edge-native workloads. Pages merged with Workers for unified platform. |
+| **Community velocity** | Strong. workerd runtime is open source. Wrangler CLI actively maintained. D1, R2, KV, Durable Objects form a cohesive platform. Active Discord and community forum. Framework integrations (Next.js, Remix, Astro, SvelteKit) are first-class. |
+| **Failure mode documentation** | Good. V8 isolate model eliminates cold starts (sub-millisecond startup). Documented limitations: 128MB memory limit, 30s CPU time (paid), no native TCP sockets (workaround via connect()), Worker size limits. Durable Objects consistency model well-documented. |
+| **Vendor lock-in risk** | MEDIUM. workerd is open-source (can self-host). Workers API aligns with Web Standards (fetch, Request, Response, crypto). WASI support improves Wasm portability. However, D1/R2/KV/Durable Objects are proprietary -- data layer lock-in is the real risk, not compute lock-in. |
+| **Cost model predictability** | HIGH. CPU-time-only billing (no charge for I/O wait) makes costs highly predictable. $5/month base includes generous allowances. No cold-start cost surprises. Most predictable cost model in the serverless space. |
+
+**Hype filter results:**
+1. Production usage: Cloudflare serves ~20% of web traffic; Workers are integral (6/6)
+2. Community velocity: open-source runtime, active ecosystem (5/6)
+3. Second-order signals: Cloudflare Workers in growing number of job postings (5/6)
+4. Failure stories: documented memory/CPU limits, documented Durable Object edge cases (5/6)
+5. Benchmark independence: third-party latency benchmarks confirm sub-ms cold starts (5/6)
+6. Revenue signal: usage-based revenue growing, not subsidized (5/6)
+
+**Verdict: Adopt now for edge-native workloads.** The edge-minion already covers
+Cloudflare Workers but frames them as CDN compute. They are also a legitimate
+full-stack serverless platform (Workers + D1 + R2 + KV). This dual identity
+needs to be reflected in agent knowledge.
+
+---
+
+### 3. Vercel -- TRIAL
+
+| Dimension | Assessment |
+|-----------|------------|
+| **Production maturity** | Production-ready for frontend-first deployments. ~$200M ARR (2025). ~550 employees. Strong Next.js integration (Vercel created Next.js). Fluid Compute model (2025) improves function efficiency. |
+| **Community velocity** | Very high for frontend ecosystem. Next.js is the dominant React meta-framework. v0 AI tool gaining traction. Active open-source community. |
+| **Failure mode documentation** | Moderate. Backend limitations well-documented: no background jobs, no persistent connections, no custom runtimes. Function timeout limits. But cost-related failure modes (bill shock at scale) are mostly documented by third parties, not by Vercel. |
+| **Vendor lock-in risk** | HIGH. Next.js features tied to Vercel (Image Optimization, ISR, Middleware). Templates use Vercel-specific APIs. Migration requires "substantial refactoring" per multiple sources. Self-hosting Next.js is possible but loses platform-specific optimizations. |
+| **Cost model predictability** | LOW. $20/mo Pro plan balloons to $500-2000/mo for moderately successful apps. Bandwidth overages, function invocations, and edge middleware cost extra. A VPS handles equivalent traffic for 10-20% of the cost at scale. The new Fluid Compute pricing (Active CPU + Provisioned Memory + Invocations) adds complexity. |
+
+**Hype filter results:**
+1. Production usage: many production sites, but mostly frontend/jamstack (4/6)
+2. Community velocity: excellent, driven by Next.js ecosystem (6/6)
+3. Second-order signals: strong hiring, conference presence (5/6)
+4. Failure stories: cost complaints are the primary failure signal (4/6)
+5. Benchmark independence: self-benchmarking dominates (Next.js benchmarks by Vercel) (3/6)
+6. Revenue signal: growing revenue, but VC-funded -- unclear if pricing is sustainable (3/6)
+
+**Verdict: Trial for frontend-first projects.** Vercel excels at developer
+experience for Next.js/React deployments. But cost unpredictability at scale
+and high vendor lock-in prevent Adopt classification. Evaluate with spending
+limits and an exit plan.
+
+---
+
+### 4. Netlify -- TRIAL (with reservations)
+
+| Dimension | Assessment |
+|-----------|------------|
+| **Production maturity** | Mature for static sites and Jamstack. Enterprise features (SSO/SCIM, audit logs, SLA). But serverless functions are secondary to static hosting -- they are "available on every plan" but not the platform's strength. |
+| **Community velocity** | Declining relative to competitors. Developer mindshare shifting to Vercel and Cloudflare. Credit-based pricing change (Sep 2025) generated negative community sentiment. |
+| **Failure mode documentation** | Moderate. Documented limitations: serverless functions "great for static content but weak for dynamic or full-stack applications." No comprehensive failure mode documentation for production serverless use. |
+| **Vendor lock-in risk** | MEDIUM. Less lock-in than Vercel (no framework ownership). Netlify Functions are AWS Lambda under the hood, so business logic is more portable. But Netlify-specific features (Edge Functions, Build Plugins) create soft lock-in. |
+| **Cost model predictability** | MEDIUM. Credit-based pricing (Sep 2025) improves transparency but changes the mental model. Enterprise plans start at $20K+/year. Less prone to bill shock than Vercel but pricing evolution suggests instability. |
+
+**Hype filter results:**
+1. Production usage: extensive for static/jamstack, limited for serverless-heavy (3/6)
+2. Community velocity: slowing relative to competitors (3/6)
+3. Second-order signals: decreasing job posting presence (3/6)
+4. Failure stories: limited because serverless is not the primary use case (2/6)
+5. Benchmark independence: insufficient independent benchmarks (2/6)
+6. Revenue signal: unclear financial health, pricing model changes suggest pressure (2/6)
+
+**Verdict: Trial, with reservations.** Netlify is fine for what it was built
+for (static sites with light serverless). For serverless-first projects, other
+platforms offer stronger foundations. Re-evaluate in 6 months; if community
+velocity continues declining, downgrade to Hold.
+
+---
+
+### 5. Deno Deploy -- ASSESS
+
+| Dimension | Assessment |
+|-----------|------------|
+| **Production maturity** | Growing but early. Deno 2 adoption "more than doubled" but from a small base. Now supports Next.js deployment. Node.js compatibility layer bridges the ecosystem gap but "lacks the depth and robustness" of Node. Pricing tiers (Free / Pro $20 / Enterprise) suggest product-market fit search. |
+| **Community velocity** | Moderate. Deno runtime is well-regarded technically. Deploy is the managed platform. Smaller contributor base than competitors. Spending limits added (Oct 2025) -- good operational maturity signal. |
+| **Failure mode documentation** | Insufficient. Limited production failure stories in the wild. The technology is not being used at sufficient scale for failure modes to be well-characterized. |
+| **Vendor lock-in risk** | LOW. Deno runtime is open source (MIT). Deploy uses Web Standard APIs (fetch, Request, Response). Code is highly portable to other V8/Wasm-based platforms. This is a genuine differentiator. |
+| **Cost model predictability** | HIGH (at small scale). Simple, transparent pricing. Spending limits available. But insufficient data on cost behavior at enterprise scale. |
+
+**Hype filter results:**
+1. Production usage: insufficient production evidence at meaningful scale (2/6)
+2. Community velocity: growing but small relative to alternatives (3/6)
+3. Second-order signals: limited job postings, no dedicated conference tracks (2/6)
+4. Failure stories: near-absent -- technology not widely deployed enough (1/6)
+5. Benchmark independence: limited third-party benchmarks (2/6)
+6. Revenue signal: small revenue, unclear sustainability (2/6)
+
+**Verdict: Assess.** Technically sound, low lock-in, but insufficient production
+signals. Worth watching for 12 months. If Deno 2 adoption continues growing
+and production case studies emerge, upgrade to Trial in Q1 2027.
+
+---
+
+## Summary Comparison Table
+
+| Platform | Ring | Production Maturity | Cost Predictability | Lock-in Risk | Best For |
+|----------|------|-------------------|-------------------|-------------|----------|
+| **AWS Lambda** | ADOPT | 10+ years, proven at massive scale | Medium (requires monitoring) | High (AWS ecosystem) | Event-driven, API backends, microservices |
+| **Cloudflare Workers** | ADOPT | 7+ years, integral to Cloudflare | High (CPU-time billing) | Medium (compute portable, data less so) | Edge-native, full-stack with D1/R2/KV |
+| **Vercel** | TRIAL | Mature for frontend | Low (bill shock at scale) | High (Next.js coupling) | Frontend-first, Next.js projects |
+| **Netlify** | TRIAL* | Mature for static | Medium (pricing in flux) | Medium (Lambda underneath) | Static sites with light serverless |
+| **Deno Deploy** | ASSESS | Growing, early | High (small scale) | Low (open standards) | Small projects, portability-first |
+
+*With reservations -- re-evaluate in 6 months.
+
+---
+
+## Is Serverless "Boring Technology"?
+
+**Partially yes, for specific patterns.** Applying Dan McKinley's "boring
+technology" framework:
+
+**Serverless IS boring when:**
+- The workload is event-driven (webhooks, queue processing, scheduled tasks)
+- The API is stateless and request/response oriented
+- Traffic is spiky or unpredictable (pay-per-use advantage)
+- The team is small and cannot afford ops overhead
+- The project is greenfield with no existing infrastructure investment
+
+**Serverless is NOT boring when:**
+- The workload requires persistent connections (WebSockets, streaming)
+- Latency SLOs are strict and cold starts are unacceptable (without provisioned concurrency)
+- The workload is compute-intensive or long-running (>15min)
+- Cost predictability is a hard requirement at high scale
+- The team needs deep debugging and observability (serverless debugging is still harder)
+
+**The correct default recommendation for greenfield projects:** Start with
+serverless unless a specific requirement disqualifies it. This is the
+"serverless-first" approach that is becoming industry consensus. The
+despicable-agents system should reflect this.
+
+---
+
+## Agent Architecture Recommendation: No 28th Agent
+
+**Recommendation: Expand iac-minion's remit. Do not create a serverless-minion.**
+
+### Rationale
+
+1. **27 agents is already at the upper bound of manageable complexity.** Adding
+   a 28th agent for a deployment model (not a technology domain) creates
+   fragmentation. Serverless touches infrastructure (iac-minion), edge compute
+   (edge-minion), frontend deployment (frontend-minion), and API design
+   (api-design-minion). A dedicated agent would have boundary conflicts with
+   all four.
+
+2. **The gap is in iac-minion, not in the roster.** The current iac-minion spec
+   (lines 722-748 of the-plan.md) lists: Terraform, Docker, Docker Compose,
+   GitHub Actions, reverse proxies, Hetzner Cloud, AWS basics, and "Server
+   deployment and operations." It has an implicit server-first bias. The fix is
+   to add serverless deployment patterns to iac-minion's remit, not to create a
+   separate agent.
+
+3. **edge-minion already covers Cloudflare Workers and Fastly Compute** but
+   frames them as CDN extensions, not as serverless platforms. Minor language
+   adjustment needed -- acknowledge that Workers is both an edge compute
+   platform AND a serverless deployment target.
+
+### Proposed Changes
+
+**iac-minion remit additions:**
+- Serverless deployment patterns (AWS Lambda, Azure Functions, GCP Cloud Functions)
+- Serverless framework selection (SAM, CDK, Serverless Framework, SST)
+- Serverless-first vs. container-first decision framework
+- Cost modeling for serverless vs. container workloads
+- Serverless CI/CD patterns (deployment packaging, layer management)
+
+**iac-minion research focus additions:**
+- AWS Lambda best practices and cost optimization
+- Serverless Framework and SST patterns
+- Serverless vs. container decision matrices
+- Serverless cost monitoring and alerting
+
+**edge-minion language adjustment:**
+- Acknowledge Cloudflare Workers as both edge compute AND full-stack serverless
+  platform (not just CDN logic)
+- Add Vercel/Netlify deployment patterns for frontend-first projects to
+  edge-minion or frontend-minion (joint decision)
+
+**iac-minion principles addition:**
+- "Default to serverless for stateless, event-driven greenfield workloads.
+  Default to containers for stateful, long-running, or compute-intensive
+  workloads. Document the reasoning when choosing either."
+
+---
+
+## Risks and Dependencies
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| iac-minion scope creep from adding serverless | Medium | Keep serverless scoped to deployment/ops patterns; application code stays with other minions |
+| Overlap between iac-minion (Lambda) and edge-minion (Workers) | Low | Clear boundary: iac-minion owns cloud-region serverless (Lambda/Azure/GCP), edge-minion owns edge serverless (Workers/Fastly) |
+| Cost model complexity for Lambda | Medium | Include cost monitoring and alerting as first-class iac-minion knowledge |
+| Vendor lock-in accumulation | High | iac-minion should include portability assessment as standard output for any serverless recommendation |
+
+---
+
+## Conditions for Re-evaluation
+
+- **6 months (Aug 2026):** Re-evaluate Netlify. If community velocity has not
+  stabilized, downgrade to Hold.
+- **12 months (Feb 2027):** Re-evaluate Deno Deploy. If production case studies
+  emerge and adoption continues growing, upgrade to Trial.
+- **Ongoing:** Monitor AWS Lambda cost model changes. The Aug 2025 INIT billing
+  change was significant; further billing changes could alter the cost
+  predictability assessment.
+- **Ongoing:** Monitor Cloudflare Workers platform expansion. If D1 and Durable
+  Objects reach maturity comparable to DynamoDB, Workers may become the default
+  serverless recommendation over Lambda for new projects (better cost model,
+  lower cold starts, global by default).
+- **If a 28th agent is reconsidered:** Only if serverless becomes a dominant
+  paradigm requiring specialized knowledge that neither iac-minion nor
+  edge-minion can absorb (e.g., serverless-specific observability, serverless
+  security hardening, serverless cost optimization as a discipline). Not
+  expected within 12 months.

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-iac-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-iac-minion-prompt.md
@@ -1,0 +1,49 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet -- you are providing your domain expertise
+to help build a comprehensive plan.
+
+## Project Task
+
+Advisory-only consultation: The despicable-agents system has a structural bias against serverless infrastructure. When starting greenfield projects, the system tends to recommend Docker + Terraform + reverse proxy stacks when serverless (Vercel, Lambda, Cloudflare Workers) would be simpler. The user observes that serverless is super simple -- no servers to manage, no scaling config, no Docker, no Terraform for basic deployments. We need to understand where the bias lives and how to correct it.
+
+## Your Planning Question
+
+You are being asked to critically assess your own knowledge base. Your current remit covers Terraform, Docker, GitHub Actions, reverse proxies, and cloud provider patterns. Serverless platforms (AWS Lambda, Cloudflare Workers, Vercel, Netlify, Deno Deploy, Cloudflare Pages) are absent from your knowledge.
+
+For a greenfield project that needs a simple API or a static site with a few server functions, compare the operational complexity of:
+(a) your current default stack (Terraform + Docker + reverse proxy + server),
+and (b) a serverless deployment (e.g., `vercel deploy` or a single Lambda).
+
+What serverless knowledge should be added to your remit? What should remain outside your scope? Should serverless be your default recommendation for greenfield, with server infrastructure as the escalation path when serverless constraints are hit?
+
+## Context
+
+Read the following files for full context:
+- /Users/ben/github/benpeter/despicable-agents/minions/iac-minion/AGENT.md (your current knowledge base)
+- /Users/ben/github/benpeter/despicable-agents/the-plan.md (lines 722-748 for your spec)
+
+The user's core observation: serverless is simpler than the current default stack for most greenfield projects. `vercel deploy` is 1 command with zero infrastructure management. Docker + Terraform + Caddy is dozens of configuration files.
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. If you believe additional specialists should be involved that
+   aren't already part of the planning, say so and explain why
+5. Return your contribution in this format:
+
+## Domain Plan Contribution: iac-minion
+
+### Recommendations
+<your expert recommendations>
+
+### Proposed Tasks
+<specific tasks that should be in the execution plan>
+
+### Risks and Concerns
+<things that could go wrong>
+
+### Additional Agents Needed
+<or "None">
+
+6. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase2-iac-minion.md

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-iac-minion.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-iac-minion.md
@@ -1,0 +1,313 @@
+# Phase 2: iac-minion Planning Contribution
+
+## Self-Assessment: The Structural Bias Is Real and Deep
+
+I have critically reviewed my own AGENT.md (277 lines) and the-plan.md spec
+(lines 722-748). The diagnosis is accurate: my entire knowledge base is
+organized around server-centric infrastructure. The word "serverless" appears
+zero times in my deployed AGENT.md. Here is the honest inventory:
+
+### What My Current Knowledge Produces for a Greenfield API
+
+For a project that needs "a simple API with a database":
+
+**My current default stack (what I would recommend today):**
+
+| Component | Files/Config Required | Ongoing Ops Burden |
+|-----------|----------------------|-------------------|
+| Terraform provider + backend | `versions.tf`, `backend.tf`, S3 bucket for state, DynamoDB for locking | State management, plan/apply workflow, state file drift |
+| Terraform compute module | `main.tf`, `variables.tf`, `outputs.tf` | Resource lifecycle, provider upgrades |
+| Terraform networking | VPC, subnets, security groups, routing | Network troubleshooting, rule auditing |
+| Docker | `Dockerfile` (multi-stage), `.dockerignore` | Image builds, registry management, layer cache, base image updates |
+| Docker Compose (dev) | `docker-compose.yml` | Local dev parity, volume mounts |
+| Reverse proxy | `Caddyfile` or `nginx.conf` | TLS cert renewal, proxy config, header management |
+| GitHub Actions | `.github/workflows/deploy.yml` (build, push, SSH deploy) | Workflow maintenance, secret rotation |
+| Server ops | SSH access, systemd units, log rotation, firewall rules | Patching, monitoring, disk space, uptime |
+
+**Conservative count: 8-12 configuration files, 4+ tools to learn, ongoing
+server maintenance.**
+
+**Serverless equivalent (Vercel + managed database):**
+
+| Component | Files/Config Required | Ongoing Ops Burden |
+|-----------|----------------------|-------------------|
+| Vercel project | `vercel.json` (optional -- zero-config for most frameworks) | None. Platform handles scaling, TLS, CDN. |
+| GitHub integration | Connect repo in Vercel dashboard (one-time) | Automatic deploys on push. No workflow file needed. |
+| Database | Vercel Postgres / Neon / PlanetScale connection string in env | Connection string rotation (annually). |
+
+**Conservative count: 0-1 configuration files, 1 tool, zero server
+maintenance.**
+
+The operational complexity ratio is roughly **10:1 in favor of serverless** for
+this class of project. This is not a marginal difference -- it is an order of
+magnitude.
+
+### Where My Knowledge Has Structural Gaps
+
+My current AGENT.md has six knowledge sections, all server-centric:
+
+1. **Terraform Infrastructure Provisioning** -- assumes you need to provision
+   infrastructure at all
+2. **Docker and Container Optimization** -- assumes you need containers
+3. **GitHub Actions CI/CD Pipelines** -- useful for both paradigms, but my
+   patterns assume "build image, push to registry, deploy to server"
+4. **Reverse Proxy Configuration** -- assumes you run your own ingress
+5. **Cloud Provider Patterns** -- only covers Hetzner (IaaS) and generic VPC
+   patterns
+6. **SSL/TLS Certificate Management** -- assumes you manage your own certs
+
+None of these sections include a decision point that says "wait -- do you
+actually need any of this?" There is no triage step that evaluates whether
+the project's requirements exceed what a serverless platform provides for free.
+
+### My Infrastructure Design Approach Is the Root Cause
+
+My "Infrastructure Design Approach" working pattern (AGENT.md lines 135-144)
+starts with:
+
+> 1. Select appropriate cloud provider(s) and services
+> 2. Design network topology (VPCs, subnets, routing, security groups)
+> 3. Choose compute resources (instance types, scaling strategy)
+> 4. Design data storage and backup strategy
+> 5. Plan CI/CD pipeline stages
+> 6. Define infrastructure observability
+> 7. Document deployment procedures and runbooks
+
+This 7-step process assumes the answer is always "provision infrastructure."
+Step 1 should actually be: **"Does this project need infrastructure at all, or
+does a managed platform eliminate the need?"** The entire workflow skips the
+most important question.
+
+## Operational Complexity Comparison: Honest Assessment
+
+### Dimension-by-Dimension Comparison
+
+| Dimension | Server Stack (Terraform+Docker+Caddy) | Serverless (Vercel/Lambda) |
+|-----------|--------------------------------------|---------------------------|
+| **Initial setup** | Hours to days. Terraform init, Docker build, proxy config, DNS, TLS, firewall. | Minutes. `vercel deploy` or connect GitHub repo. |
+| **Deployment** | Multi-step: build image, push registry, SSH/pull, restart service, verify. | `git push` triggers automatic deploy. Zero-downtime by default. |
+| **Scaling** | Manual or auto-scaling config. Capacity planning required. | Automatic. Zero configuration. Pay per invocation. |
+| **TLS certificates** | Caddy automates well, but you still run Caddy. Nginx requires certbot. | Platform handles entirely. You never see a certificate. |
+| **Monitoring** | You set up Prometheus, Grafana, alerting, log aggregation. | Platform provides dashboards, function logs, error tracking out of the box. |
+| **Security patching** | You patch the OS, runtime, base images, proxy. | Platform patches everything. You patch your dependencies only. |
+| **Cost at low traffic** | Server runs 24/7 regardless of traffic. Minimum ~$5/month (Hetzner CX22). | Free tier covers most hobby/small projects. Pay-per-use beyond that. |
+| **Cost at high traffic** | Predictable. Server cost is fixed regardless of request count. | Can spike unpredictably. Lambda at 1M req/day costs more than a server. |
+| **Rollback** | Redeploy previous image, or blue-green switch. Requires setup. | One click in dashboard or `vercel rollback`. Instant. Built-in. |
+| **Local development** | Docker Compose mirrors prod reasonably well. | Varies. Vercel dev is good. Lambda local dev (SAM, serverless-offline) is rougher. |
+| **Vendor lock-in** | Low. Terraform is multi-cloud. Docker runs anywhere. | Medium to high. Vercel-specific APIs, Next.js coupling, platform-specific middleware. |
+| **Execution limits** | None. Your server, your rules. | Function timeout (Lambda: 15min), payload size, cold starts, no persistent connections, no local filesystem. |
+
+### The Verdict
+
+For greenfield projects that are:
+- Simple APIs (CRUD, webhooks, form handlers)
+- Static sites with some dynamic server functions
+- Prototype / MVP / early-stage products
+- Low to moderate traffic (under ~100K requests/day)
+- Standard web frameworks (Next.js, Nuxt, SvelteKit, Remix, Astro)
+
+**Serverless is unambiguously simpler.** My current default stack is
+over-engineering by any honest measure.
+
+For projects that are:
+- Long-running processes (video encoding, ML inference, websocket servers)
+- High and predictable traffic (cost optimization matters)
+- Custom runtime requirements (specific OS packages, GPU access, custom networking)
+- Multi-service architectures with complex networking
+- Compliance-constrained (data residency, specific security controls)
+
+**Server infrastructure is the right choice.** This is where my current
+knowledge shines.
+
+## Recommendations: What Should Change in My Remit
+
+### 1. Add a "Deployment Strategy Triage" as Step 0
+
+Before any infrastructure design work, I should evaluate whether serverless
+is sufficient. This is the single most impactful change.
+
+**Proposed triage decision tree:**
+
+```
+Does the project need any of these?
+  - Long-running processes (>30s per request)
+  - Persistent connections (WebSockets, SSE without platform support)
+  - Custom OS-level dependencies or GPU
+  - Compliance-mandated infrastructure control
+  - Predictable high traffic (>500K req/day, cost-sensitive)
+
+  YES to any -> Server infrastructure (my current stack)
+  NO to all  -> Serverless platform (Vercel, Cloudflare Pages, Lambda)
+```
+
+This triage should be the FIRST thing in my "Infrastructure Design Approach"
+working pattern, before any Terraform or Docker work begins.
+
+### 2. Add Serverless Platform Knowledge (Bounded Scope)
+
+I should know enough about serverless to:
+- **Recommend** the right platform for a given use case
+- **Configure** basic deployments (vercel.json, serverless.yml, wrangler.toml)
+- **Identify** when a project is hitting serverless limits and needs to escalate
+- **Design** CI/CD for serverless (GitHub Actions integration, preview deploys)
+
+**Specific platforms to cover:**
+
+| Platform | Why | Depth |
+|----------|-----|-------|
+| **Vercel** | Dominant for Next.js/React, zero-config deploys, excellent DX | Deep: config, env vars, edge functions, preview deploys |
+| **Cloudflare Pages/Workers** | Edge-first, great for APIs and sites, generous free tier | Moderate: basic wrangler config, Pages deployment. Deep Workers knowledge stays with edge-minion. |
+| **AWS Lambda** | Enterprise standard, most flexible serverless compute | Moderate: SAM/CDK basics, API Gateway integration, IAM roles |
+| **Netlify** | Good for static sites, simpler than Vercel for non-Next.js | Light: know when to recommend it, basic config |
+| **Deno Deploy** | Emerging, good for Deno/Fresh projects | Light: awareness level only |
+
+### 3. What Should Remain OUTSIDE My Scope
+
+- **Deep Cloudflare Workers development** (Durable Objects, KV patterns, D1
+  queries, Workers-specific middleware) -- this stays with edge-minion
+- **Serverless application architecture** (function decomposition, event-driven
+  design, saga patterns) -- this is application design, not infrastructure
+- **Serverless database selection** (Neon vs PlanetScale vs Turso) -- stays
+  with data-minion
+- **Platform-specific framework optimization** (Next.js on Vercel middleware,
+  Remix loaders) -- stays with frontend-minion
+
+The boundary: I own "how to deploy and operate" (including the decision of
+whether to deploy serverless or server). I do not own "how to architect the
+application for the deployment target."
+
+### 4. Restructure My Knowledge to Be Decision-First
+
+Current structure (tool-first):
+```
+Core Knowledge
+  Terraform Infrastructure Provisioning
+  Docker and Container Optimization
+  GitHub Actions CI/CD Pipelines
+  Reverse Proxy Configuration
+  Cloud Provider Patterns
+  ...
+```
+
+Proposed structure (decision-first):
+```
+Core Knowledge
+  Deployment Strategy Selection     <-- NEW: triage serverless vs server
+  Serverless Deployment Patterns    <-- NEW: Vercel, Lambda, CF Pages
+  Server Infrastructure Patterns    <-- RENAMED: existing Terraform/Docker/proxy content
+  GitHub Actions CI/CD Pipelines    <-- UPDATED: add serverless deploy patterns
+  Cloud Provider Patterns           <-- UPDATED: add serverless platform patterns
+  Cost Optimization                 <-- UPDATED: add serverless cost model
+  ...
+```
+
+### 5. Update Cost Optimization Knowledge
+
+My current cost section is entirely about servers (rightsizing, reserved
+instances, spot instances, auto-scaling). Serverless has a fundamentally
+different cost model that I currently cannot reason about:
+
+- **Pay-per-invocation**: Lambda charges per request + compute time. Free tier
+  covers 1M requests/month.
+- **Platform free tiers**: Vercel free tier is generous for personal/small
+  projects. Cloudflare Workers free tier is 100K requests/day.
+- **Cost crossover point**: There is a traffic threshold where serverless
+  becomes more expensive than a dedicated server. I should know how to
+  calculate this.
+- **Hidden costs**: Data transfer, external API calls from functions, database
+  connection overhead (serverless functions open new connections per invocation
+  without connection pooling).
+
+### 6. Serverless Should Be My Default for Greenfield
+
+Yes, unequivocally. The evidence is clear:
+
+- Serverless eliminates entire categories of operational work (patching,
+  scaling, TLS, monitoring infrastructure)
+- The "complexity" of serverless is in its constraints, not its setup. And
+  constraints are only problems if you hit them.
+- Server infrastructure should be the **escalation path** when serverless
+  constraints are encountered, not the starting point
+- This aligns with YAGNI: don't provision servers until you need servers
+
+The recommended default hierarchy:
+1. **Serverless platform** (Vercel, Cloudflare Pages, Netlify) -- start here
+2. **Serverless compute** (Lambda, Cloudflare Workers) -- when you need custom
+   backend logic beyond what the platform provides
+3. **Containers on managed platforms** (ECS Fargate, Cloud Run, Fly.io) --
+   when you need long-running processes or custom runtimes but still want
+   managed infrastructure
+4. **Self-managed servers** (Terraform + Docker + proxy) -- when you need full
+   control, have compliance requirements, or have optimized for cost at scale
+
+## Risks and Dependencies
+
+### Risks
+
+1. **Knowledge breadth vs depth**: Adding serverless to my remit risks
+   spreading my knowledge too thin. Mitigation: keep serverless knowledge at
+   the "deployment and operations" level, not the "application architecture"
+   level.
+
+2. **Overlap with edge-minion**: Cloudflare Workers/Pages sits in both
+   domains. Need clear boundary: I own "should we use Workers for this
+   project?" (deployment decision); edge-minion owns "how to write efficient
+   Worker code" (implementation).
+
+3. **Stale platform knowledge**: Serverless platforms evolve rapidly (Vercel
+   ships features monthly). My knowledge could become outdated faster than
+   server-centric knowledge. Mitigation: focus on stable patterns (deploy
+   commands, config files, limit awareness) rather than platform-specific
+   features.
+
+4. **Over-correction risk**: Swinging from "always recommend servers" to
+   "always recommend serverless" would be equally wrong. The triage decision
+   tree is the safeguard.
+
+### Dependencies
+
+- **margo recalibration**: If margo still scores serverless as "new technology:
+  10 points" after this advisory, my serverless-first recommendation will be
+  overruled at review time. Margo's complexity budget must recognize serverless
+  as the simpler option for qualifying projects.
+
+- **Delegation table update**: The-plan.md delegation table needs a
+  "serverless deployment" row routing to iac-minion (primary) with edge-minion
+  (supporting for Workers-based deployments).
+
+- **edge-minion boundary agreement**: Need explicit boundary definition so
+  Cloudflare Workers/Pages deployments are not orphaned between two agents or
+  double-covered.
+
+## Suggested Delegation Table Additions
+
+| Task Type | Primary | Supporting |
+|-----------|---------|------------|
+| Serverless platform deployment (Vercel, Netlify) | iac-minion | devx-minion |
+| Lambda / serverless compute provisioning | iac-minion | edge-minion |
+| Serverless-to-server migration | iac-minion | devx-minion |
+| Greenfield deployment strategy selection | iac-minion | margo |
+
+## Additional Specialists
+
+No additional specialists beyond the five already in this advisory are needed
+for the planning phase. If this moves to execution (modifying AGENT.md files),
+the following would be relevant:
+
+- **software-docs-minion**: For updating any architecture documentation that
+  references deployment patterns
+- **test-minion**: For guidance on how testing patterns change with serverless
+  (local dev, integration testing against deployed functions)
+
+## Summary
+
+The bias is real, structural, and I am its primary vector. My entire knowledge
+base assumes you need infrastructure. For the majority of greenfield projects,
+you do not. The fix is:
+
+1. Add deployment strategy triage as Step 0 (serverless vs server decision)
+2. Add bounded serverless platform knowledge (Vercel, Lambda, CF Pages)
+3. Make serverless the default, server infrastructure the escalation
+4. Restructure knowledge to be decision-first rather than tool-first
+5. Update cost optimization for serverless cost models
+6. Coordinate with margo (complexity budget) and edge-minion (boundary)

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-lucy-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-lucy-prompt.md
@@ -1,0 +1,54 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet -- you are providing your domain expertise
+to help build a comprehensive plan.
+
+## Project Task
+
+Advisory-only consultation: The despicable-agents system has a structural bias against serverless infrastructure. We need to determine the right entry point to encode "serverless-first for greenfield" as a system convention. The bias is emergent -- not from any single explicit rule, but from gaps in agent knowledge and heuristic framing.
+
+## Your Planning Question
+
+If we want to encode "serverless-first for greenfield projects" as a system-level default, where should this convention live? Options:
+(a) project CLAUDE.md as a technology preference
+(b) margo's heuristics as a complexity calibration
+(c) iac-minion's working patterns as a "start here" default
+(d) the delegation table in the-plan.md as a new routing row
+(e) a combination
+
+From your perspective as convention enforcer, which encoding is most enforceable, least likely to drift, and most discoverable by agents during planning? Consider the resolution hierarchy (CLAUDE.md vs agent knowledge vs delegation table) and where a "greenfield defaults" directive would have the most consistent effect.
+
+Also consider: this is an agent system designed to be generic and publishable (Apache 2.0). "Serverless-first" as a hardcoded default in agent files makes the agents opinionated in a way that may not suit all users. Should the convention be in CLAUDE.md (per-project) rather than baked into agents?
+
+## Context
+
+Read the following files:
+- /Users/ben/github/benpeter/despicable-agents/lucy/AGENT.md (your current spec)
+- /Users/ben/github/benpeter/despicable-agents/CLAUDE.md (project conventions)
+- /Users/ben/github/benpeter/despicable-agents/the-plan.md (design principles, lines 1-76)
+
+The bias is distributed across:
+1. iac-minion's knowledge gap (no serverless in remit)
+2. margo's complexity budget (scores novelty, not operational burden)
+3. Delegation table (no serverless routing row)
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. Return your contribution in this format:
+
+## Domain Plan Contribution: lucy
+
+### Recommendations
+<your expert recommendations>
+
+### Proposed Tasks
+<specific tasks>
+
+### Risks and Concerns
+<things that could go wrong>
+
+### Additional Agents Needed
+<or "None">
+
+5. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase2-lucy.md

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-lucy.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-lucy.md
@@ -1,0 +1,153 @@
+# Phase 2: Lucy -- Convention Enforceability Analysis
+
+**Planning question**: Where should "serverless-first for greenfield" live to be most enforceable, least likely to drift, and most discoverable during planning?
+
+---
+
+## 1. Framing the Problem from a Convention Enforcement Perspective
+
+I enforce conventions by verifying that plans and code comply with declared directives. A convention only works if it is (a) written down in a location I can read, (b) unambiguous enough to produce APPROVE/BLOCK verdicts, and (c) in the resolution path that agents consult before making decisions. Anything that does not meet all three criteria will drift.
+
+The question has a critical secondary dimension the task description already flags: this is an Apache 2.0 publishable agent system. Hardcoding opinionated infrastructure defaults into agent AGENT.md files makes the system less generic. That constraint must weigh heavily in the recommendation.
+
+---
+
+## 2. Analysis of Each Option
+
+### (a) Project CLAUDE.md as a technology preference
+
+**Enforceability: HIGH.** CLAUDE.md is loaded into every agent session. I already verify CLAUDE.md compliance as part of my standard review workflow. A directive like "For greenfield infrastructure, prefer serverless/managed services over self-hosted unless the workload has sustained, predictable compute requirements" would be checkable against any plan that proposes infrastructure.
+
+**Drift risk: LOW.** CLAUDE.md is the canonical convention source. It is human-edited, version-controlled, and diff-visible in PRs. Changes require deliberate human action. This is the mechanism already used for the "prefer lightweight, vanilla solutions" directive in the current CLAUDE.md (line 44-47), which is enforced project-wide.
+
+**Discoverability: HIGH.** Every agent in the system receives CLAUDE.md context. It is Priority 2 in the resolution hierarchy (or Priority 1 via CLAUDE.local.md). No agent can miss it.
+
+**Publishability impact: NONE -- but only if placed in CLAUDE.local.md or the target project's CLAUDE.md.** If placed in despicable-agents' own CLAUDE.md, it becomes an opinionated stance in a published tool. The correct pattern is: the despicable-agents project itself does not declare this preference (its agents are generic), but the user's target project CLAUDE.md does. This is identical to how `CLAUDE.local.md` already handles the Adobe-adjacent technology bias without baking it into published agents.
+
+**Verdict**: Best option for per-project enforcement. Not suitable for hardcoding in the despicable-agents repo's own CLAUDE.md.
+
+### (b) Margo's heuristics as a complexity calibration
+
+**Enforceability: MEDIUM.** Margo's complexity budget (AGENT.md lines 55-62) currently scores: new technology (10 pts), new service (5 pts), new abstraction layer (3 pts), new dependency (1 pt). This scoring system does not distinguish between "new technology: self-hosted Kubernetes" and "new technology: AWS Lambda." Both get 10 points. To encode a serverless preference, margo would need a heuristic like "operational burden compounds: self-managed infrastructure incurs ongoing ops cost that should be counted against the complexity budget; serverless/managed services reduce operational complexity even if they add a new technology."
+
+**Drift risk: MEDIUM.** Margo's heuristics are baked into AGENT.md, which is generated from the-plan.md spec. Changes require spec version bumps and rebuilds. This is more rigid than CLAUDE.md (good for stability, bad for per-project customization). However, margo's job is simplicity enforcement, not infrastructure strategy. Adding infrastructure topology preferences to margo's remit is a scope expansion for the agent itself.
+
+**Discoverability: LOW for infrastructure decisions.** Margo participates in Phase 3.5 architecture review (always), but iac-minion makes the initial infrastructure proposal in Phase 2. By the time margo reviews, the infrastructure choice may already be baked into the plan. Margo can flag complexity, but cannot steer the initial proposal.
+
+**Publishability impact: PROBLEMATIC.** Making margo opinionated about serverless vs. self-hosted embeds an infrastructure stance into a generic simplicity enforcer. Not all users want serverless-first. This violates the "generic domain specialists" design principle (the-plan.md line 11).
+
+**Verdict**: Margo could benefit from an operational complexity dimension in the budget, but should not become the primary vehicle for serverless preferences. That would be scope creep on margo's remit.
+
+### (c) iac-minion's working patterns as a "start here" default
+
+**Enforceability: LOW-MEDIUM.** iac-minion's knowledge shapes what it proposes, but iac-minion only participates when infrastructure work is in scope. The current iac-minion spec (the-plan.md lines 722-748) and AGENT.md show a clear server-centric orientation: Terraform, Docker, Docker Compose, Caddy, Nginx, Hetzner Cloud, server deployment strategies (canary, blue-green, rolling). Serverless appears exactly once in the RESEARCH.md (line 247, as a cost optimization afterthought). The agent has no serverless working patterns, no Lambda/Cloud Functions knowledge, no serverless-first decision framework.
+
+**Drift risk: LOW (for the agent itself).** Agent knowledge is versioned and rebuilt from the-plan.md. However, "start here" defaults in an agent's working patterns are soft guidance, not hard conventions. Without external enforcement (CLAUDE.md or a review checkpoint), iac-minion could still default to its deeper knowledge (server-based) when a user prompt is ambiguous.
+
+**Discoverability: MEDIUM.** Discoverable by nefario when delegating infrastructure tasks, and by iac-minion itself during execution. Not discoverable by other agents who might make infrastructure-adjacent decisions (e.g., data-minion choosing between self-hosted Postgres and Neon, edge-minion choosing between self-hosted Nginx and Cloudflare Workers).
+
+**Publishability impact: PROBLEMATIC.** Same issue as (b). Making iac-minion default to serverless makes it opinionated in the published artifact. A user running these agents for an on-prem enterprise deployment would find the default unhelpful.
+
+**Verdict**: iac-minion's knowledge gap is a real problem regardless of where the convention lives. The agent needs serverless knowledge to execute on serverless plans. But "start here" defaults in agent knowledge are not the right enforcement mechanism for a project preference.
+
+### (d) Delegation table in the-plan.md as a new routing row
+
+**Enforceability: LOW.** The delegation table routes task types to agents. It answers "who does this work?" not "how should they do it?" Adding a row like "Serverless infrastructure | iac-minion | edge-minion" tells nefario who to assign, but does not tell iac-minion to prefer serverless. Routing is not policy.
+
+**Drift risk: LOW (stable location).** The delegation table changes infrequently. But a routing row cannot express "prefer X over Y for greenfield."
+
+**Discoverability: HIGH for nefario.** Nefario consults the delegation table during META-PLAN. However, the table cannot encode decision heuristics, only assignments.
+
+**Publishability impact: NEUTRAL.** A routing row for serverless tasks is reasonable -- it says "these tasks exist" not "prefer these tasks."
+
+**Verdict**: A serverless routing row in the delegation table is useful as a gap fix (so nefario knows serverless tasks exist and who handles them), but it cannot encode a preference or default. Wrong tool for the stated goal.
+
+### (e) A combination
+
+This is the correct answer, but a specific combination, not all of the above.
+
+---
+
+## 3. Recommendation: Layered Approach
+
+### Layer 1 -- Target project CLAUDE.md (primary enforcement point)
+
+The "serverless-first for greenfield" preference belongs in the CLAUDE.md of each target project that wants it, not in the despicable-agents system itself. This is the same pattern already used for "prefer lightweight, vanilla solutions" at the user level.
+
+Example directive for a target project's CLAUDE.md:
+```
+## Infrastructure Defaults
+- For greenfield projects, prefer serverless/managed services (Lambda, Cloud Functions,
+  managed databases) over self-hosted infrastructure unless the workload has sustained
+  predictable compute that makes reserved instances cheaper.
+- Justify self-hosted infrastructure against the serverless alternative in the plan.
+```
+
+This is:
+- Enforceable by lucy (I check CLAUDE.md compliance on every plan)
+- Discoverable by every agent (CLAUDE.md is loaded into all sessions)
+- Per-project customizable (different projects can have different defaults)
+- Not baked into published agents (preserves generic/publishable constraint)
+
+### Layer 2 -- iac-minion knowledge gap (prerequisite fix)
+
+Regardless of where the preference lives, iac-minion cannot execute serverless plans with its current knowledge. The spec (the-plan.md lines 722-748) and the AGENT.md are purely server-centric. This is a knowledge gap, not a convention question. Fix it by:
+
+1. Expanding iac-minion's remit in the-plan.md to include serverless patterns (Lambda, Cloud Functions, API Gateway, serverless frameworks like SST/Serverless Framework)
+2. Adding serverless working patterns to RESEARCH.md and AGENT.md
+3. Adding a "greenfield decision framework" working pattern: "When starting from scratch, evaluate serverless vs. self-hosted based on: traffic pattern (bursty vs. steady), latency requirements, cold start tolerance, cost at expected scale"
+
+This makes iac-minion capable of proposing serverless when appropriate, without making it the default. The default comes from CLAUDE.md.
+
+### Layer 3 -- Delegation table gap (routing fix)
+
+Add serverless-relevant rows to the delegation table so nefario knows to involve iac-minion for serverless tasks:
+
+| Task Type | Primary | Supporting |
+|-----------|---------|------------|
+| Serverless function design | iac-minion | api-design-minion |
+| Serverless deployment & packaging | iac-minion | test-minion |
+
+This ensures nefario routes serverless work correctly rather than dropping it or misassigning it.
+
+### Layer 3.5 -- Margo operational complexity awareness (optional enhancement)
+
+Margo's complexity budget could benefit from an "operational complexity" dimension that recognizes ongoing ops burden as a complexity cost. This is not serverless-specific -- it is a general improvement to complexity assessment. Currently the budget scores one-time adoption costs but not ongoing operational costs (patching, scaling, monitoring self-hosted infra). A note like:
+
+> "Operational burden is recurring complexity: self-managed infrastructure incurs ongoing patching, scaling, and incident response costs that should factor into the complexity budget."
+
+This naturally favors managed/serverless services in margo's reviews without making margo opinionated about a specific infrastructure topology. It is a calibration improvement, not a policy addition.
+
+---
+
+## 4. What NOT to Do
+
+| Anti-pattern | Why |
+|-------------|-----|
+| Hardcode "serverless-first" in iac-minion's AGENT.md | Makes a generic published agent opinionated. Users with on-prem requirements would fight the default. |
+| Add it to despicable-agents' own CLAUDE.md | This repo's CLAUDE.md governs the agent development project, not target projects. Wrong scope. |
+| Make margo block self-hosted proposals | Margo enforces simplicity, not infrastructure topology. This would be scope creep on margo's role. |
+| Create a new agent (e.g., "serverless-minion") | The task explicitly says "advisory-only consultation." Creating a new agent is a solution far beyond the stated scope. iac-minion should have this knowledge. |
+
+---
+
+## 5. Risks and Dependencies
+
+| Risk | Mitigation |
+|------|-----------|
+| Users forget to add the directive to their project CLAUDE.md | Provide a documented template/example in despicable-agents docs or a "project setup" checklist. |
+| iac-minion knowledge expansion takes the agent off its core competency | Keep serverless knowledge focused on IaC aspects (provisioning, deployment, packaging) not application architecture. |
+| Margo operational complexity calibration is subjective | Frame it as a heuristic ("consider"), not a hard rule ("always penalize"). |
+| Delegation table rows may not fully cover serverless task routing | Review after iac-minion knowledge expansion to see if additional rows are needed. |
+
+---
+
+## 6. Summary Verdict
+
+**ADVISE**: The convention is most enforceable, least drift-prone, and most discoverable in the target project's CLAUDE.md, not in the agent system itself. The agent system needs capability fixes (iac-minion knowledge gap, delegation table gap) but should not encode the preference as a hardcoded default. This preserves the publishable/generic design principle while giving lucy a concrete, checkable directive to enforce during plan reviews.
+
+The combination is:
+1. **CLAUDE.md of target project** -- the preference (primary, enforceable, per-project)
+2. **iac-minion spec expansion** -- the capability (prerequisite, without it the preference is unexecutable)
+3. **Delegation table rows** -- the routing (so nefario knows serverless tasks exist)
+4. **Margo operational complexity note** -- the calibration (optional, general improvement)

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-margo-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-margo-prompt.md
@@ -1,0 +1,46 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet -- you are providing your domain expertise
+to help build a comprehensive plan.
+
+## Project Task
+
+Advisory-only consultation: The despicable-agents system has a structural bias against serverless infrastructure. When starting greenfield projects, the system flags serverless as over-engineering / YAGNI / anti-KISS. But serverless is actually simpler than server-based alternatives for most greenfield cases (no servers, no scaling, no Docker, no Terraform). We need to recalibrate the system's complexity heuristics.
+
+## Your Planning Question
+
+Your complexity budget assigns "New technology: 10 points" and "New service: 5 points." Your "Boring Technology" heuristic frames decade-old tech as safe and newer tech as innovation-token spends. But serverless platforms (AWS Lambda launched 2014, Vercel production since 2020, Cloudflare Workers since 2018) are now boring technology by any reasonable measure. Meanwhile, Terraform state management, Docker layer optimization, and reverse proxy configuration are all accidental complexity that serverless eliminates entirely.
+
+How should your complexity budget and "boring technology" heuristic be updated to correctly account for the fact that serverless is often simpler, not more complex? Specifically:
+(a) Should "serverless deployment" score LOWER than "server + container + orchestration" on your complexity budget?
+(b) Should the "boring technology" heuristic include serverless platforms as boring?
+(c) What signals should trigger margo to flag server infrastructure as over-engineering when serverless would suffice?
+
+## Context
+
+Read the following files:
+- /Users/ben/github/benpeter/despicable-agents/margo/AGENT.md (your current heuristics)
+- /Users/ben/github/benpeter/despicable-agents/margo/RESEARCH.md (your research backing)
+
+The user's core observation: `vercel deploy` is 1 command. Docker + Terraform + Caddy is dozens of config files. The complexity budget should reflect operational burden, not just novelty.
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. Return your contribution in this format:
+
+## Domain Plan Contribution: margo
+
+### Recommendations
+<your expert recommendations>
+
+### Proposed Tasks
+<specific tasks>
+
+### Risks and Concerns
+<things that could go wrong>
+
+### Additional Agents Needed
+<or "None">
+
+5. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase2-margo.md

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-margo.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase2-margo.md
@@ -1,0 +1,454 @@
+# Phase 2: margo -- Complexity Heuristic Recalibration for Serverless
+
+## Summary
+
+The current complexity budget and boring technology heuristics contain a structural
+bias that penalizes serverless adoption by measuring novelty instead of operational
+burden. This creates a paradox where margo -- the simplicity enforcer -- steers
+teams toward objectively more complex deployment stacks (Docker + Terraform +
+reverse proxy + OS patching) when a single `vercel deploy` or `wrangler deploy`
+would satisfy requirements with less accidental complexity. The heuristics need
+recalibration, not replacement.
+
+---
+
+## Diagnosis: Where the Current Heuristics Fail
+
+### Problem 1: The Complexity Budget Counts Technologies, Not Operational Burden
+
+The current budget assigns flat costs:
+
+```
+- New technology: 10 points
+- New service: 5 points
+- New abstraction layer: 3 points
+- New dependency: 1 point
+```
+
+These costs measure *what you add to the stack*, not *what you have to operate*.
+Under this model, deploying a Node.js API to Vercel scores:
+
+- Vercel (new technology): 10 points
+- **Total: 10 points**
+
+But deploying the same API to a VPS with Docker and Caddy scores:
+
+- Docker (new technology): 10 points
+- Caddy (new technology): 10 points
+- VPS provider (new service): 5 points
+- **Total: 25 points**
+
+Wait -- the current budget actually penalizes the server-based approach harder?
+Not in practice. Here is the failure mode: if a team already uses Docker and
+Caddy (they are "existing technology," cost 0), then adding Vercel is a net +10.
+The budget measures *marginal novelty*, not *total operational burden*. A team
+deep in server infrastructure never pays the complexity cost for its accumulated
+toolchain -- it only pays when adding something new.
+
+This means the heuristic structurally favors whatever the team is already doing,
+even if what they are already doing is objectively more complex. For greenfield
+projects with no existing stack, this creates an implicit bias toward whatever
+the reviewing agent considers "default" -- and the boring technology heuristic
+nudges that default toward server-based infrastructure.
+
+### Problem 2: "Boring Technology" Conflates Age with Operational Maturity
+
+The current boring technology section states:
+
+> "Boring tech has decades of production hardening, well-understood failure modes,
+> staffable talent pools, and community documentation."
+
+And:
+
+> "Using a technology that's existed for a year or less consumes a token."
+
+By these criteria:
+
+| Technology | Launch Year | Age | Production Hardening | Staffable |
+|------------|------------|-----|---------------------|-----------|
+| AWS Lambda | 2014 | 12 years | Enormous | Yes |
+| Cloudflare Workers | 2018 | 8 years | Large | Yes |
+| Vercel | 2020 (production) | 6 years | Large | Yes |
+| Docker | 2013 | 13 years | Enormous | Yes |
+| Terraform | 2014 | 12 years | Enormous | Yes |
+| Caddy | 2015 | 11 years | Moderate | Moderate |
+| Kubernetes | 2014 | 12 years | Enormous | Yes, but expensive |
+
+Lambda is as old as Terraform. Workers is older than many Docker orchestration
+patterns teams use today. Vercel has six years of production use. None of these
+are innovation token spends by any reasonable reading of the heuristic.
+
+Yet the boring technology section frames the choice as "Postgres, Redis, Nginx"
+versus new and risky. Serverless platforms are conspicuously absent from the
+examples, creating an implicit association between "boring = servers you manage"
+and "new = anything else."
+
+### Problem 3: Accidental Complexity Lives in the Server Stack, Not in Serverless
+
+The AGENT.md and RESEARCH.md define accidental complexity as "implementation
+choices -- poor abstractions, unnecessary indirection, over-engineered frameworks."
+Consider what a server-based deployment requires that serverless eliminates:
+
+| Concern | Server-Based | Serverless |
+|---------|-------------|-----------|
+| OS patching | Your problem (or Dockerfile rebuild) | Platform handles |
+| TLS certificates | Caddy automates, but you configure | Platform handles |
+| Scaling | Manual or auto-scaling config | Platform handles |
+| Process supervision | systemd/supervisord/Docker restart | Platform handles |
+| Reverse proxy | Caddy/Nginx config files | Platform handles |
+| Port management | Your config | Platform handles |
+| Log rotation | Your config | Platform handles |
+| State file management | Terraform state locking, remote backends | N/A |
+| Container registry | Push/pull/prune/auth | N/A |
+| Network configuration | VPC, security groups, firewall rules | Platform handles |
+
+Every row in the "Server-Based" column is accidental complexity -- none of it
+comes from the problem domain. It exists purely because of the implementation
+choice to run your own servers. By margo's own framework, this should be
+flagged and challenged.
+
+---
+
+## Answers to the Three Questions
+
+### (a) Should "serverless deployment" score LOWER than "server + container + orchestration"?
+
+**Yes.** The complexity budget should measure operational burden, not just
+technology count. I recommend a two-dimensional scoring model:
+
+**Adoption cost** (one-time): learning curve, migration effort, new failure modes
+to understand.
+
+**Operational cost** (ongoing): what you must maintain, monitor, patch, scale,
+and debug in production over the lifetime of the project.
+
+For greenfield projects, the adoption cost comparison is:
+
+| Approach | Config Files | Concepts to Learn | Failure Modes to Understand |
+|----------|-------------|-------------------|---------------------------|
+| `vercel deploy` | 0-1 (vercel.json optional) | 1 (the platform) | Cold starts, function limits |
+| Docker + Terraform + Caddy | 3+ (Dockerfile, *.tf, Caddyfile) | 3+ (containers, IaC, reverse proxy) | Container networking, state drift, cert renewal, OOM, disk space |
+
+For operational cost:
+
+| Approach | Ongoing Maintenance |
+|----------|-------------------|
+| Serverless | Monitor function errors, manage environment variables |
+| Server-based | OS updates, Docker image rebuilds, Terraform state, cert monitoring, disk/memory monitoring, backup strategy, security patching |
+
+The budget should reflect this. Proposed revision:
+
+```
+Complexity Budget (approximate costs):
+- New technology (unfamiliar to team): 10 points
+- New self-managed service: 8 points (deployment, networking, monitoring, patching, scaling)
+- New managed/serverless service: 3 points (vendor API, limits, failure modes)
+- New abstraction layer: 3 points (indirection, cognitive load)
+- New dependency: 1 point (supply chain risk, maintenance)
+```
+
+The key change: splitting "new service" into self-managed (8 points, raised from
+5 because the original underweighted operational burden) and managed/serverless
+(3 points, because the platform absorbs most operational complexity).
+
+### (b) Should the "boring technology" heuristic include serverless platforms as boring?
+
+**Yes.** AWS Lambda (2014), Cloudflare Workers (2018), and Vercel (2020) meet
+every criterion the heuristic defines for boring technology:
+
+- **Production hardening**: Lambda runs a significant fraction of the internet's
+  backend compute. Workers handles trillions of requests. Vercel hosts millions
+  of deployments.
+- **Well-understood failure modes**: Cold starts, execution limits, vendor
+  lock-in, egress costs -- all documented extensively.
+- **Staffable talent pools**: Any Node.js developer can write a Vercel function
+  or a Lambda handler. The deployment model is simpler to learn than Docker +
+  Terraform.
+- **Community documentation**: Massive ecosystems, Stack Overflow coverage,
+  official docs, tutorials.
+
+The boring technology section should explicitly name serverless platforms
+alongside Postgres, Redis, and Nginx as examples of boring, proven technology.
+Not doing so creates a false impression that only self-hosted infrastructure
+qualifies as boring.
+
+Proposed addition to the Boring Technology section:
+
+> **Serverless platforms are boring technology.** AWS Lambda (2014), Cloudflare
+> Workers (2018), and Vercel (2020) have years of production hardening, well-
+> understood failure modes (cold starts, execution limits, vendor lock-in),
+> staffable talent pools, and extensive documentation. Deploying to a serverless
+> platform is not an innovation token spend -- it is the operationally simpler
+> default for most greenfield web services and APIs.
+
+### (c) What signals should trigger margo to flag server infrastructure as over-engineering?
+
+I propose a new detection pattern: **Infrastructure Over-Engineering**. This
+mirrors the existing "Premature Microservices" case study but targets deployment
+complexity.
+
+**Trigger signals -- flag server infrastructure when:**
+
+1. **No scaling requirement exists**: The project has no evidence of needing
+   custom scaling behavior. Default serverless auto-scaling suffices.
+
+2. **No long-running process requirement**: The workload fits within serverless
+   execution limits (typically 10-30 seconds for API responses, up to 15 minutes
+   for background jobs on Lambda). If every request completes in under 30 seconds,
+   you do not need a persistent server.
+
+3. **No stateful process requirement**: The application does not need persistent
+   in-memory state, WebSocket connections held for hours, or local filesystem
+   storage between requests. (Note: short-lived WebSockets and server-sent events
+   are supported on Workers and some serverless platforms.)
+
+4. **Config file count exceeds code file count**: When the deployment
+   configuration (Dockerfile, docker-compose.yml, Caddyfile, terraform/*.tf,
+   nginx.conf, systemd units) approaches or exceeds the application code in
+   complexity, the infrastructure is disproportionate to the problem.
+
+5. **Team size is small (1-5 developers)**: Small teams cannot afford the
+   operational overhead of maintaining servers, containers, and IaC. The
+   cognitive load of infrastructure competes directly with feature development.
+
+6. **Greenfield project with no existing infrastructure**: No sunk cost in
+   server tooling. The marginal complexity of serverless is near zero.
+
+**Counter-signals -- server infrastructure IS justified when:**
+
+- Workloads require persistent connections (long-lived WebSockets, streaming for
+  minutes/hours)
+- Execution time regularly exceeds serverless limits
+- The application needs GPU access, custom system libraries, or specific OS
+  configurations
+- Cost analysis shows serverless pricing is significantly more expensive at the
+  project's actual scale (not hypothetical future scale)
+- Regulatory or compliance requirements mandate specific infrastructure control
+- The team already operates server infrastructure and adding serverless would
+  genuinely increase total complexity
+
+---
+
+## Proposed Changes to margo AGENT.md
+
+### 1. Revise the Complexity Budget section
+
+Replace the flat service cost with the two-tier model (self-managed vs.
+managed/serverless). Add a note that the budget measures operational burden,
+not just novelty.
+
+### 2. Expand the Boring Technology section
+
+Add serverless platforms explicitly as boring technology with examples. Reframe
+the innovation token test: it is about *unknown failure modes and operational
+risk*, not about *calendar age* alone.
+
+### 3. Add an "Infrastructure Over-Engineering" detection pattern
+
+Add to either YAGNI Enforcement or create a new subsection under Scope Creep /
+Premature Optimization. Include the trigger signals and counter-signals above.
+
+### 4. Add an "Infrastructure Over-Engineering" case study to RESEARCH.md
+
+Parallel to the existing "Premature Microservices" case study:
+
+> **Case Study: Infrastructure Over-Engineering**
+>
+> **Problem**: Team deploys a three-endpoint API using Docker + Terraform +
+> Caddy + GitHub Actions CI/CD pipeline targeting a VPS.
+>
+> **Consequences**:
+> - Dockerfile, docker-compose.yml, Caddyfile, 4 Terraform files, 2 GitHub
+>   Actions workflows -- before a single line of application code
+> - Team spends 40% of first sprint on infrastructure instead of features
+> - OS security patch requires Dockerfile rebuild, image push, Terraform apply
+> - Debugging requires SSH access, Docker logs, Caddy logs, system journals
+>
+> **Simpler alternative**: `vercel deploy` or `wrangler deploy`. Zero
+> infrastructure config files. Deployment is a single command. Monitoring and
+> logs provided by platform. Team ships features from day one.
+>
+> **Lesson**: For greenfield web services and APIs without specific
+> infrastructure requirements (GPU, long-running processes, persistent state),
+> serverless is the simpler default. Add server infrastructure when you have
+> evidence you need it, not before.
+
+### 5. Update YAGNI detection patterns
+
+Add to the existing detection patterns list:
+
+> - Server infrastructure (Docker, Terraform, reverse proxy) for a stateless
+>   web API that fits within serverless limits
+
+### 6. Revise the "Premature Optimization" red flags
+
+Add:
+
+> - Provisioning dedicated servers "for performance" without evidence that
+>   serverless cold starts or execution limits are a bottleneck
+
+---
+
+## Risks and Dependencies
+
+### Risks
+
+1. **Over-correction risk**: Margo could start reflexively flagging all server
+   infrastructure, even when justified. The counter-signals list above must be
+   equally prominent to prevent this. Serverless is not always simpler -- the
+   heuristic must remain context-dependent.
+
+2. **Vendor lock-in blind spot**: Serverless platforms have real lock-in costs
+   (proprietary APIs, migration difficulty). The recalibrated heuristic should
+   acknowledge this as a known trade-off, not ignore it. Lock-in is a real cost
+   but a *future* cost that must be weighed against the *present* cost of
+   operational complexity.
+
+3. **Edge cases**: Some workloads genuinely straddle the boundary (occasional
+   long-running jobs, some WebSocket usage, moderate state requirements). The
+   heuristic should guide teams to evaluate rather than prescribe.
+
+### Dependencies
+
+- **iac-minion coordination**: The iac-minion (`/Users/ben/github/benpeter/despicable-agents/minions/iac-minion/AGENT.md`)
+  currently leads with Terraform, Docker, and reverse proxy knowledge. If margo
+  starts flagging these as over-engineering for simple projects, the iac-minion
+  should be updated to also recommend serverless-first for greenfield projects
+  that fit the profile. Otherwise the two agents will give contradictory advice.
+
+- **edge-minion overlap**: The edge-minion (`/Users/ben/github/benpeter/despicable-agents/minions/edge-minion/AGENT.md`)
+  already covers Cloudflare Workers deeply. There should be clear delegation:
+  margo flags when serverless is simpler (governance), edge-minion advises on
+  which serverless platform to use (domain expertise).
+
+- **the-plan.md spec version**: If margo's AGENT.md changes, the spec-version
+  in `the-plan.md` should be bumped from 1.0 to 1.1 to trigger regeneration.
+
+---
+
+## Specific Text Changes (Draft)
+
+### Complexity Budget (AGENT.md, lines 55-59)
+
+**Current:**
+```
+Every project has a finite complexity budget. Approximate costs:
+- New technology: 10 points (failure modes, learning curve, ops burden)
+- New service: 5 points (deployment, networking, monitoring)
+- New abstraction layer: 3 points (indirection, cognitive load)
+- New dependency: 1 point (supply chain risk, maintenance)
+```
+
+**Proposed:**
+```
+Every project has a finite complexity budget. Approximate costs:
+- New technology (unfamiliar to team): 10 points (failure modes, learning curve)
+- New self-managed service: 8 points (deployment, networking, monitoring, patching, scaling)
+- New managed/serverless service: 3 points (vendor API surface, platform limits)
+- New abstraction layer: 3 points (indirection, cognitive load)
+- New dependency: 1 point (supply chain risk, maintenance)
+
+Budget measures operational burden, not novelty. A single serverless deployment
+command carries less ongoing cost than a stack of Dockerfiles, Terraform configs,
+and reverse proxy rules -- even when the server tools are familiar.
+```
+
+### Boring Technology (AGENT.md, lines 171-179)
+
+**Current:**
+```
+Choose boring technology. Every organization gets roughly three innovation
+tokens. Boring tech has decades of production hardening, well-understood failure
+modes, staffable talent pools, and community documentation. The long-term cost
+of keeping a system running vastly exceeds build-time inconvenience.
+
+AI coding tools make this more critical, not less -- resist the temptation to
+adopt multiple new technologies simultaneously just because AI can scaffold them.
+```
+
+**Proposed:**
+```
+Choose boring technology. Every organization gets roughly three innovation
+tokens. Boring tech has years of production hardening, well-understood failure
+modes, staffable talent pools, and community documentation. The long-term cost
+of keeping a system running vastly exceeds build-time inconvenience.
+
+Serverless platforms are boring technology. AWS Lambda (2014), Cloudflare
+Workers (2018), and Vercel (2020) have years of production hardening,
+well-understood failure modes (cold starts, execution limits, vendor coupling),
+and large talent pools. Deploying to serverless is not an innovation token
+spend for most web services and APIs.
+
+AI coding tools make this more critical, not less -- resist the temptation to
+adopt multiple new technologies simultaneously just because AI can scaffold them.
+```
+
+### New YAGNI Detection Pattern (AGENT.md, add to lines 70-76)
+
+Add to the existing detection patterns list:
+```
+- Server infrastructure (Docker, Terraform, reverse proxy) for stateless APIs
+  that fit within serverless execution limits
+```
+
+### New Section: Infrastructure Over-Engineering (AGENT.md, after Premature Optimization)
+
+```
+## Infrastructure Over-Engineering Detection
+
+Server infrastructure is essential complexity when workloads demand it. For
+stateless web services and APIs, it is often accidental complexity -- operational
+burden chosen by habit rather than requirement.
+
+**Flag server infrastructure when**:
+- No scaling, long-running process, or persistent state requirement exists
+- Deployment config files (Dockerfile, *.tf, Caddyfile) rival application code
+  in complexity
+- Team is small (1-5 developers) and infrastructure competes with feature work
+- Greenfield project with no existing server infrastructure investment
+
+**Server infrastructure IS justified when**:
+- Workloads need persistent connections, GPU, custom OS, or exceed serverless
+  execution limits
+- Cost analysis at actual (not hypothetical) scale favors servers
+- Regulatory requirements mandate specific infrastructure control
+- Team already operates server infrastructure and serverless would increase
+  total complexity
+
+**The test**: "Does this workload have a specific requirement that serverless
+cannot meet?" If no, serverless is the simpler default.
+```
+
+---
+
+## RESEARCH.md Updates Required
+
+The RESEARCH.md currently has no content about deployment complexity comparison,
+serverless as boring technology, or infrastructure over-engineering as an
+anti-pattern. The following sections should be added:
+
+1. **Infrastructure Over-Engineering Case Study** (parallel to existing case studies)
+2. **Serverless as Boring Technology** subsection under the Boring Technology section
+3. **Deployment Complexity Comparison** -- concrete comparison of config file
+   counts and operational burden between serverless and server-based approaches
+4. **Serverless Limitations** -- honest accounting of cold starts, execution
+   limits, vendor lock-in, debugging difficulty, and cost at scale
+
+---
+
+## Verdict on the Bias
+
+The bias is real and structural. It stems from three compounding factors:
+
+1. The complexity budget penalizes adding new things but not maintaining existing
+   complex things
+2. The boring technology examples implicitly equate "boring" with "self-hosted"
+3. There is no detection pattern for infrastructure over-engineering, even though
+   patterns exist for premature microservices, premature optimization, and SOLID
+   over-application
+
+The fix is straightforward: recalibrate the budget to measure operational burden,
+update the boring technology examples, and add an infrastructure over-engineering
+detection pattern. These changes are consistent with margo's core mission --
+challenging accidental complexity wherever it appears, including in deployment
+choices.

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3-synthesis-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3-synthesis-prompt.md
@@ -1,0 +1,50 @@
+MODE: SYNTHESIS
+
+You are synthesizing specialist planning contributions into a final advisory report.
+
+## Original Task
+
+Advisory-only request -- no execution, no post-processing. Consult specialists on whether the despicable-agents system has a serverless bias, where it lives, and how to correct it. Determine:
+1. Where anti-serverless bias lives in the system
+2. The right entry point to encode serverless-first for greenfield
+3. Whether a dedicated serverless agent is needed or existing agents can absorb it
+4. What greenfield defaults should look like
+
+## Specialist Contributions
+
+Read the following scratch files for full specialist contributions:
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase2-iac-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase2-margo.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase2-gru.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase2-lucy.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase2-devx-minion.md
+
+## Key consensus across specialists:
+
+1. **iac-minion** (planning): Serverless should be the default for greenfield. Add deployment strategy triage as Step 0. Restructure from tool-first to decision-first. Operational complexity ratio is 10:1 (server vs serverless). Critical: margo coordination required.
+
+2. **margo** (planning): Split complexity budget (self-managed 8pts vs managed/serverless 3pts). Add "Infrastructure Over-Engineering" detection pattern. Add serverless to boring tech examples. Risk: over-correction.
+
+3. **gru** (planning): Lambda and CF Workers are ADOPT. Vercel is TRIAL. No new agent needed -- expand iac-minion and edge-minion. Vendor lock-in is highest-severity risk.
+
+4. **lucy** (planning): CLAUDE.md is most enforceable entry point for preferences. Agents stay generic (publishability). The bias is 3 gaps not 1 convention. Layered fix needed.
+
+5. **devx-minion** (planning): 50:1 time-to-first-deploy penalty. Define 5-level escalation path. Current system starts at Level 4, should start at Level 0-1. Complexity should be opt-in, not opt-out.
+
+## External Skills Context
+No external skills detected relevant to this advisory.
+
+## Instructions
+
+This is an ADVISORY-ONLY synthesis. There is no execution plan -- the output is a consolidated advisory report with recommendations.
+
+1. Review all specialist contributions
+2. Resolve any conflicts between recommendations
+3. Synthesize into a coherent advisory with:
+   - Root cause analysis (where the bias lives)
+   - Recommended changes (prioritized, with specific entry points)
+   - Agent roster recommendation (new agent vs. distributed knowledge)
+   - Greenfield defaults recommendation
+   - Implementation roadmap (if the user decides to act)
+4. Be specific about WHAT to change and WHERE -- reference file paths, section names, line numbers
+5. Write your complete synthesis to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase3-synthesis.md

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3-synthesis.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3-synthesis.md
@@ -1,0 +1,369 @@
+# Phase 3: Synthesis -- Serverless Bias Advisory Report
+
+## Executive Summary
+
+Five specialists independently confirmed the same diagnosis: the despicable-agents system has a structural anti-serverless bias. It is not in one place -- it is distributed across three compounding gaps: (1) iac-minion has zero serverless knowledge and defaults to servers, (2) margo's complexity heuristics penalize novelty instead of operational burden, and (3) the delegation table has no routing for serverless tasks. The bias is real, measurable, and fixable without adding a new agent.
+
+All five specialists converge on the same corrective architecture:
+- **No 28th agent.** Expand iac-minion and adjust edge-minion's framing.
+- **CLAUDE.md of target projects** is the right place for "serverless-first" preferences (not baked into published agents).
+- **iac-minion, margo, and the delegation table** need capability and calibration fixes.
+- **Vendor lock-in** is the highest-severity risk to monitor.
+
+---
+
+## 1. Root Cause Analysis: Where the Bias Lives
+
+The bias is not a single misconfiguration. It is three independent gaps that compound.
+
+### Gap 1: iac-minion Has No Serverless Knowledge (Primary Vector)
+
+**Location**: `the-plan.md` lines 722-748 (iac-minion spec), `minions/iac-minion/AGENT.md` (deployed agent)
+
+The iac-minion spec lists eight remit items: Terraform, Docker, Docker Compose, GitHub Actions, reverse proxies, cloud provider patterns, cost optimization, server deployment and operations. The word "serverless" appears zero times. The agent's "Infrastructure Design Approach" working pattern (AGENT.md lines 135-144) begins with "Select appropriate cloud provider(s) and services" and proceeds through VPC design, compute selection, and deployment procedures -- all assuming infrastructure exists. There is no Step 0 that asks "does this project need infrastructure at all?"
+
+**Impact**: When nefario delegates a greenfield deployment task to iac-minion, the agent's knowledge produces a Docker + Terraform + Caddy stack regardless of whether the project needs it. The 10:1 operational complexity ratio (iac-minion's own assessment) means the default recommendation carries an order of magnitude more ops burden than the serverless alternative for qualifying projects.
+
+### Gap 2: margo's Complexity Budget Penalizes Novelty, Not Operational Burden
+
+**Location**: `margo/AGENT.md` lines 55-59 (Complexity Budget), lines 171-179 (Boring Technology)
+
+The complexity budget scores: new technology (10 pts), new service (5 pts), new abstraction layer (3 pts), new dependency (1 pt). These costs measure what you *add*, not what you *operate*. A team already using Docker + Terraform + Caddy pays zero complexity points for maintaining those tools, but pays 10 points for adopting Vercel -- even though Vercel eliminates entire categories of operational work. The budget structurally favors incumbency over simplicity.
+
+The "Boring Technology" section frames boring tech as "decades of production hardening" with implicit examples of self-hosted infrastructure. Serverless platforms (Lambda: 2014, Workers: 2018, Vercel: 2020) are conspicuously absent from the boring tech examples, despite meeting every stated criterion.
+
+**Impact**: margo -- the agent whose job is to catch over-engineering -- currently cannot detect infrastructure over-engineering. A plan proposing Docker + Terraform + Caddy for a three-endpoint API passes margo's review unchallenged.
+
+### Gap 3: Delegation Table Has No Serverless Routing
+
+**Location**: `the-plan.md` delegation table (nefario's AGENT.md mirrors it)
+
+The delegation table routes "Infrastructure provisioning" to iac-minion. There is no row for "deployment strategy selection," "serverless deployment," or any task type that distinguishes between server-based and serverless infrastructure. When a user asks nefario to deploy a greenfield project, nefario routes it as "infrastructure provisioning" because that is the only matching row -- which presupposes that infrastructure needs provisioning.
+
+**Impact**: Nefario cannot route serverless work correctly. The routing itself encodes the assumption that deployment requires infrastructure.
+
+### Compounding Effect
+
+The three gaps reinforce each other:
+1. Nefario routes deployment work to iac-minion (delegation table assumes infrastructure)
+2. iac-minion proposes servers (only knowledge it has)
+3. margo approves the plan (complexity budget does not penalize operational burden)
+4. Result: server infrastructure for every project, regardless of whether it is needed
+
+Breaking any one of these three links would improve outcomes. Fixing all three eliminates the bias.
+
+---
+
+## 2. Recommended Changes (Prioritized)
+
+### Priority 1: Expand iac-minion's Remit and Knowledge
+
+**Unanimity**: All five specialists agree this is the prerequisite fix. Without serverless knowledge in iac-minion, no convention or heuristic change can produce serverless recommendations.
+
+**What to change in `the-plan.md` (iac-minion spec, lines 722-748)**:
+
+Add to the Remit list:
+```
+- Deployment strategy selection (serverless vs. container vs. self-managed)
+- Serverless deployment patterns (Vercel, Cloudflare Pages, AWS Lambda, Netlify)
+- Serverless cost modeling and escalation triggers
+```
+
+Add to Research focus:
+```
+Serverless deployment patterns (Vercel, Cloudflare Pages/Workers, AWS Lambda + API Gateway),
+serverless vs. container decision frameworks, serverless cost modeling and crossover analysis.
+```
+
+**What to change in iac-minion's AGENT.md knowledge structure** (requires spec version bump + rebuild):
+
+1. Add a new first section: **Deployment Strategy Selection** -- a triage decision tree that evaluates whether a project needs infrastructure before any Terraform or Docker work begins. The tree from iac-minion's contribution (does the project need long-running processes, persistent connections, custom OS dependencies, compliance-mandated control, or high-traffic cost optimization? NO to all = serverless) is the right starting point.
+
+2. Add a new section: **Serverless Deployment Patterns** -- covering Vercel (deep: config, env vars, edge functions, preview deploys), Cloudflare Pages (moderate: basic wrangler config, deployment), AWS Lambda (moderate: SAM/CDK basics, API Gateway integration), Netlify (light: when to recommend it).
+
+3. Rename existing server-centric sections to make the decision-first structure explicit:
+   - "Terraform Infrastructure Provisioning" becomes part of "Server Infrastructure Patterns"
+   - "Docker and Container Optimization" stays but is positioned as Level 3-4 (containers when serverless is insufficient)
+
+4. Update the "Infrastructure Design Approach" working pattern to begin with deployment strategy triage before any infrastructure design.
+
+**Boundary with edge-minion**: iac-minion owns "should we use serverless and which platform?" (deployment decision). edge-minion owns "how to write efficient Worker/edge code" (implementation). For Cloudflare Workers/Pages: iac-minion recommends the platform; edge-minion implements the Workers code. This boundary is already implicit in edge-minion's "Does NOT do: Origin server infrastructure (-> iac-minion)" -- extend it symmetrically.
+
+**Spec version**: Bump iac-minion from 1.0 to 1.1.
+
+### Priority 2: Recalibrate margo's Complexity Heuristics
+
+**Unanimity**: All five specialists identify margo's complexity budget as a compounding factor. margo and lucy agree the change should be a calibration improvement, not an opinionated stance.
+
+**What to change in `the-plan.md` (margo spec)** and **`margo/AGENT.md`**:
+
+1. **Split the "New service" cost** in the Complexity Budget (AGENT.md lines 55-59):
+
+   Current:
+   ```
+   - New service: 5 points (deployment, networking, monitoring)
+   ```
+
+   Proposed:
+   ```
+   - New self-managed service: 8 points (deployment, networking, monitoring, patching, scaling)
+   - New managed/serverless service: 3 points (vendor API surface, platform limits)
+   ```
+
+   Rationale: Self-managed services carry ongoing operational burden (patching, scaling, incident response) that the original flat score underweighted. Managed/serverless services eliminate most operational burden and should score lower. The budget should measure operational burden, not just technology count.
+
+2. **Add serverless platforms to the Boring Technology examples** (AGENT.md lines 171-179):
+
+   After the existing paragraph, add:
+   ```
+   Serverless platforms are boring technology. AWS Lambda (2014), Cloudflare
+   Workers (2018), and Vercel (2020) have years of production hardening,
+   well-understood failure modes (cold starts, execution limits, vendor coupling),
+   and large talent pools. Deploying to serverless is not an innovation token
+   spend for most web services and APIs.
+   ```
+
+3. **Add an "Infrastructure Over-Engineering" detection pattern** (new subsection after Premature Optimization):
+
+   Trigger signals: no scaling/long-running/persistent-state requirement, config files rivaling application code in complexity, small team (1-5), greenfield with no existing infra investment.
+
+   Counter-signals: persistent connections, GPU/custom OS needs, cost analysis at actual scale favoring servers, regulatory requirements, existing server infra where serverless would increase total complexity.
+
+4. **Add to YAGNI detection patterns** (AGENT.md lines 70-76):
+   ```
+   - Server infrastructure (Docker, Terraform, reverse proxy) for stateless APIs
+     that fit within serverless execution limits
+   ```
+
+**Spec version**: Bump margo from 1.0 to 1.1.
+
+### Priority 3: Update the Delegation Table
+
+**What to change in `the-plan.md`** (delegation table) and **nefario's AGENT.md** (mirrored table):
+
+Add these rows to the Infrastructure & Data section:
+
+| Task Type | Primary | Supporting |
+|-----------|---------|------------|
+| Deployment strategy selection | iac-minion | devx-minion |
+| Serverless platform deployment (Vercel, Cloudflare Pages, Netlify) | iac-minion | edge-minion |
+| Serverless compute provisioning (Lambda, Cloud Functions) | iac-minion | edge-minion |
+| Serverless-to-server migration | iac-minion | devx-minion |
+
+These rows ensure nefario can distinguish "decide how to deploy" (strategy selection) from "provision infrastructure" (server-specific), and routes serverless work to agents who have the knowledge to handle it.
+
+### Priority 4: Provide a CLAUDE.md Template for Projects
+
+**What lucy recommends (and all specialists agree)**: The "serverless-first for greenfield" preference belongs in each target project's CLAUDE.md, not in the published agent system. This is the same pattern already used for "prefer lightweight, vanilla solutions."
+
+**Deliverable**: A documented example in the despicable-agents docs (e.g., `docs/guides/greenfield-defaults.md` or a section in `docs/orchestration.md`) showing how to add infrastructure preferences to a project's CLAUDE.md:
+
+```markdown
+## Infrastructure Defaults
+
+- For greenfield projects, prefer serverless/managed services (Vercel, Cloudflare Pages,
+  Lambda, managed databases) over self-hosted infrastructure unless the workload has
+  specific requirements that serverless cannot meet (persistent connections, long-running
+  processes, compliance-mandated infrastructure control, cost optimization at scale).
+- Justify self-hosted infrastructure against the serverless alternative in the plan.
+```
+
+This gives users a copy-paste directive that:
+- lucy can enforce (CLAUDE.md compliance check)
+- Every agent receives (CLAUDE.md is loaded into all sessions)
+- Is per-project customizable (different projects, different defaults)
+- Does not make published agents opinionated
+
+---
+
+## 3. Agent Roster Recommendation: No New Agent
+
+**Unanimous**: All five specialists recommend against a dedicated serverless-minion (28th agent).
+
+**Rationale** (gru's assessment is definitive here):
+- 27 agents is already at the upper bound of manageable complexity
+- Serverless is a deployment model that crosses infrastructure (iac-minion), edge compute (edge-minion), frontend deployment (frontend-minion), and API design (api-design-minion). A dedicated agent would have boundary conflicts with four existing agents.
+- The gap is in iac-minion's knowledge, not in the roster. Filling the knowledge gap is cheaper and less disruptive than adding a new agent.
+
+**Distribution of serverless knowledge after the fix**:
+
+| Agent | Serverless Responsibility | Depth |
+|-------|--------------------------|-------|
+| iac-minion | Deployment strategy selection, platform recommendation, basic deployment config (vercel.json, basic wrangler.toml, SAM templates), cost modeling, escalation triggers | Deep: decision framework and deployment patterns |
+| edge-minion | Cloudflare Workers/Pages as a full-stack serverless platform (not just CDN compute), Fastly Compute, edge function development | Deep: implementation and edge-native patterns |
+| margo | Flagging infrastructure over-engineering, complexity budget scoring that recognizes managed vs. self-managed | Heuristic: detection patterns, not platform knowledge |
+| devx-minion | Time-to-first-deploy benchmarks, deployment complexity scoring, local dev parity assessment | Metric: DX quality measurement |
+| frontend-minion | Framework-specific deployment (Next.js on Vercel, SvelteKit on Cloudflare, Astro anywhere) | Existing: framework deployment already in scope |
+
+**Condition for re-evaluation** (gru): Only if serverless becomes a dominant paradigm requiring specialized knowledge that neither iac-minion nor edge-minion can absorb (e.g., serverless-specific observability, serverless security hardening as a discipline). Not expected within 12 months.
+
+---
+
+## 4. Greenfield Defaults Recommendation
+
+### The Escalation Ladder
+
+devx-minion's 5-level deployment escalation path is the recommended default mental model. The current system starts at Level 4 (self-managed). It should start at Level 0.
+
+| Level | Path | Time to Deploy | When |
+|-------|------|---------------|------|
+| 0 | Static hosting (Cloudflare Pages, GitHub Pages) | < 2 min | HTML/CSS/JS only, static generators |
+| 1 | Static + API routes (Vercel, CF Workers/Pages Functions) | < 5 min | Server logic needed but individual functions |
+| 2 | Full serverless app (Vercel + DB, Workers + D1, Lambda + API GW) | 5-15 min | Full web app with SSR, API, database |
+| 3 | Serverless containers (Fargate, Cloud Run, Fly.io) | 15-30 min | Long-running processes, WebSockets, custom runtimes |
+| 4 | Self-managed (Docker + Terraform + proxy) | 1-4 hours | Compliance, cost optimization at scale, bare-metal needs |
+
+**The principle**: Complexity is opt-in, not opt-out. Start at the simplest level. Escalate only when a specific constraint demands it. Document which constraint triggered the escalation.
+
+### Escalation Triggers
+
+| Signal | From | To | Rationale |
+|--------|------|-----|-----------|
+| Need persistent WebSocket connections | Level 1-2 | Level 3 | Serverless platforms limit connection duration |
+| Function execution consistently > 30s | Level 1-2 | Level 3 | Serverless timeout limits |
+| Monthly bill > $500/service | Level 2 | Level 3 | Cost optimization threshold |
+| Custom binary deps or OS packages | Level 2 | Level 3 | Serverless runtimes have limited system access |
+| Data residency / compliance mandates | Level 2-3 | Level 4 | Need infrastructure control |
+| Monthly bill > $5k/service | Level 3 | Level 4 | Significant savings from dedicated infra |
+| GPU, specific CPU, bare-metal perf | Any | Level 4 | Serverless cannot provide hardware-specific compute |
+
+### Technology Maturity (gru's Assessment)
+
+| Platform | Ring | Lock-in Risk | Best For |
+|----------|------|-------------|----------|
+| AWS Lambda | ADOPT | High (AWS ecosystem) | Event-driven, API backends, microservices |
+| Cloudflare Workers | ADOPT | Medium (compute portable, data less so) | Edge-native, full-stack with D1/R2/KV |
+| Vercel | TRIAL | High (Next.js coupling) | Frontend-first, Next.js projects |
+| Netlify | TRIAL* | Medium (Lambda underneath) | Static sites with light serverless |
+| Deno Deploy | ASSESS | Low (open standards) | Small projects, portability-first |
+
+*Netlify: re-evaluate in 6 months. If community velocity continues declining, downgrade to Hold.
+
+---
+
+## 5. Conflict Resolution
+
+### Conflict: Who Owns Serverless Deployment Config?
+
+devx-minion proposes routing "serverless deployment config" to edge-minion as primary. iac-minion and gru propose iac-minion as primary for all deployment decisions.
+
+**Resolution**: iac-minion is primary for deployment strategy selection and platform-level config (vercel.json, basic wrangler.toml, serverless.yml). edge-minion is primary for edge-specific implementation (Workers code, Durable Objects, edge-side logic). This preserves the existing boundary: iac-minion owns "how to deploy," edge-minion owns "how to compute at the edge."
+
+The delegation table additions reflect this: "Serverless platform deployment" routes to iac-minion (primary) with edge-minion (supporting), not the reverse.
+
+### Conflict: How Opinionated Should margo Become?
+
+margo proposes specific trigger signals and counter-signals for infrastructure over-engineering. lucy cautions that making margo opinionated about infrastructure topology is scope creep.
+
+**Resolution**: lucy is correct that the preference belongs in CLAUDE.md, not in margo. But margo's contribution is not about preference -- it is about detection. margo should detect when infrastructure complexity is disproportionate to the problem (a simplicity question, squarely in margo's remit), without prescribing a specific alternative. The "Infrastructure Over-Engineering" detection pattern asks "does this workload have a specific requirement that serverless cannot meet?" -- this is a simplicity test, not an infrastructure topology preference. Include it.
+
+### Conflict: Complexity Budget Scoring
+
+margo proposes self-managed service at 8 points (up from 5). devx-minion proposes a deployment complexity score with Kubernetes at 25 points. The two scales are incompatible.
+
+**Resolution**: Use margo's two-tier budget split (self-managed: 8, managed/serverless: 3) as the change to the Complexity Budget. devx-minion's deployment complexity scoring is a useful DX metric but is a different measurement -- it can live in devx-minion's knowledge as a DX benchmark, not in margo's complexity budget.
+
+---
+
+## 6. Risks and Mitigations
+
+### Risk 1: Over-Correction (MEDIUM)
+
+Swinging from "always recommend servers" to "always recommend serverless" would be equally wrong.
+
+**Mitigation**: The triage decision tree includes explicit counter-signals (persistent connections, long-running processes, compliance, cost at scale). margo's Infrastructure Over-Engineering detection pattern includes equally prominent "server infrastructure IS justified when" signals. The escalation ladder is bidirectional -- devx-minion's de-escalation triggers catch over-provisioned infrastructure, and counter-signals catch under-provisioned infrastructure.
+
+### Risk 2: Vendor Lock-in Accumulation (HIGH -- gru's highest severity)
+
+Serverless platforms have real lock-in costs. Lambda uses proprietary event models and IAM. Vercel couples to Next.js. Cloudflare's data layer (D1, KV, R2) is proprietary.
+
+**Mitigation**: iac-minion's serverless knowledge should include portability assessment as standard output. Keep business logic in portable libraries; use serverless as a thin invocation layer. Recommend standard interfaces (Web Standard APIs, standard SQL, S3-compatible storage). The escalation ladder's Level 3 (serverless containers) provides an exit path when platform constraints are hit. gru's recommendation: "Vendor lock-in becomes a real concern when monthly bill exceeds $5k or when you need capabilities the platform does not offer. Below that threshold, optimize for speed, not portability."
+
+### Risk 3: Knowledge Breadth vs. Depth for iac-minion (MEDIUM)
+
+Adding serverless to iac-minion's remit risks spreading its knowledge too thin.
+
+**Mitigation**: Keep serverless knowledge at the "deployment and operations" level, not the "application architecture" level. Deep Workers development stays with edge-minion. Database selection stays with data-minion. Framework optimization stays with frontend-minion. iac-minion owns the deployment decision and platform config, not the application code running on the platform.
+
+### Risk 4: Publishability Constraint (LOW)
+
+Changes to AGENT.md files must keep agents generic and vendor-neutral (Apache 2.0).
+
+**Mitigation**: lucy's layered approach preserves this. Agents gain *capability* (iac-minion can reason about serverless), not *opinion* (agents do not default to serverless). The "serverless-first" preference lives in each target project's CLAUDE.md, not in the published agents. margo's changes are framed as simplicity detection (generic) not infrastructure preference (opinionated).
+
+### Risk 5: Stale Platform Knowledge (MEDIUM)
+
+Serverless platforms evolve rapidly. Vercel ships features monthly. Pricing changes regularly.
+
+**Mitigation**: Focus agent knowledge on stable patterns (deployment commands, config file formats, limit awareness, cost models) rather than platform-specific features. gru's technology radar provides a re-evaluation cadence: Netlify in 6 months, Deno Deploy in 12 months, Lambda cost model ongoing.
+
+---
+
+## 7. Implementation Roadmap
+
+If the user decides to act on this advisory, the recommended execution sequence is:
+
+### Phase A: Spec Changes (the-plan.md)
+
+Prerequisite for all other phases. Requires human approval since the-plan.md is human-edited.
+
+1. Bump iac-minion spec from 1.0 to 1.1: add serverless remit items, update research focus
+2. Bump margo spec from 1.0 to 1.1: add complexity budget split, boring tech update, infrastructure over-engineering detection
+3. Add delegation table rows for serverless routing
+4. Review edge-minion spec: add acknowledgment that Cloudflare Workers/Pages is also a full-stack serverless platform, not only CDN compute
+
+### Phase B: Agent Rebuilds
+
+After spec changes are approved. Use `/despicable-lab` to regenerate.
+
+1. Rebuild iac-minion AGENT.md from updated spec (decision-first knowledge structure, triage working pattern, serverless deployment patterns)
+2. Rebuild margo AGENT.md from updated spec (two-tier budget, boring tech examples, infrastructure over-engineering detection)
+3. Update iac-minion RESEARCH.md with serverless deployment research
+4. Update margo RESEARCH.md with infrastructure over-engineering case study
+
+### Phase C: Nefario Updates
+
+After agent rebuilds.
+
+1. Mirror new delegation table rows into nefario's AGENT.md
+2. No other nefario changes needed -- nefario follows the delegation table, not infrastructure opinions
+
+### Phase D: Documentation
+
+After all agent changes.
+
+1. Add greenfield defaults guidance to docs (CLAUDE.md template for projects)
+2. Update `docs/orchestration.md` if delegation table changes affect routing examples
+
+### Phase E: Verification
+
+1. Dry-run test: present nefario with "deploy a simple API with a database" for a greenfield project that has the serverless-first CLAUDE.md directive. Verify iac-minion proposes serverless. Verify margo does not flag it as complexity. Verify the delegation routes correctly.
+2. Counter-test: present the same task for a project that needs persistent WebSocket connections. Verify iac-minion proposes Level 3 or 4. Verify the escalation is documented.
+
+---
+
+## 8. What NOT to Do
+
+| Anti-pattern | Why | Who flagged it |
+|-------------|-----|----------------|
+| Create a 28th agent (serverless-minion) | Boundary conflicts with 4 existing agents. The gap is knowledge, not roster. | gru, lucy, devx-minion |
+| Hardcode "serverless-first" in iac-minion AGENT.md | Makes a generic published agent opinionated. Users with on-prem requirements would fight the default. | lucy |
+| Add the preference to despicable-agents' own CLAUDE.md | Wrong scope. That CLAUDE.md governs agent development, not target projects. | lucy |
+| Make margo block self-hosted proposals | Margo enforces simplicity, not infrastructure topology. Blocking is scope creep. | lucy, margo |
+| Swing to "always recommend serverless" | Equally wrong as the current bias. The triage tree must genuinely evaluate constraints. | iac-minion, margo, devx-minion |
+| Ignore vendor lock-in | Real cost. Include portability assessment as standard iac-minion output. | gru (highest severity) |
+
+---
+
+## 9. Summary of Specialist Convergence
+
+| Question | Consensus | Dissent |
+|----------|-----------|---------|
+| Is the bias real? | Yes, unanimous, structural, measurable | None |
+| Where does it live? | Three gaps: iac-minion knowledge, margo heuristics, delegation table | None (all five identified the same gaps) |
+| New agent needed? | No. Expand iac-minion, adjust edge-minion framing. | None |
+| Where should the preference live? | Target project CLAUDE.md (primary), with agent capability fixes as prerequisites | None |
+| What should greenfield defaults look like? | Start at Level 0-1 (serverless), escalate only on specific constraints | None |
+| Highest risk? | Vendor lock-in (gru), over-correction (margo, iac-minion, devx-minion) | Severity ranking varies |
+
+The five specialists reached remarkably similar conclusions independently. There are no unresolved disagreements. The three minor conflicts (routing ownership, margo scope, budget scoring) are resolved above with rationale.

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-lucy-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-lucy-prompt.md
@@ -1,0 +1,22 @@
+You are reviewing a delegation plan before execution begins.
+Your role: identify gaps, risks, or concerns from your domain.
+
+## Delegation Plan
+Read the full plan from: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase3-synthesis.md
+
+## Your Review Focus
+Convention and intent alignment review:
+- Does the synthesis faithfully represent the user's original question about serverless bias?
+- Are the recommended entry points (CLAUDE.md, agent specs, delegation table) consistent with the project's existing conventions?
+- Does the plan respect the publishability constraint (Apache 2.0, no vendor opinions baked in)?
+- Is there goal drift -- does the advisory answer the question that was asked, or has it expanded scope?
+
+## Instructions
+Return exactly one verdict:
+- APPROVE: No concerns from your domain.
+- ADVISE: <list specific non-blocking warnings>
+- BLOCK: <describe the blocking issue and what must change>
+
+Write your verdict to: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase3.5-lucy.md
+
+Be concise. Only flag issues within your domain expertise.

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-lucy.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-lucy.md
@@ -1,0 +1,72 @@
+# Phase 3.5: Lucy -- Convention and Intent Alignment Review
+
+## Verdict: APPROVE
+
+---
+
+## Requirements Traceability
+
+| User Requirement | Synthesis Coverage | Status |
+|-----------------|-------------------|--------|
+| Advisory-only, no execution | Synthesis is a report with recommendations; Section 7 is labeled "If the user decides to act"; no files are modified | COVERED |
+| Diagnose the anti-serverless bias | Section 1 (Root Cause Analysis) identifies three structural gaps with specific file locations and line numbers, all verified accurate | COVERED |
+| Do we need a serverless agent? | Section 3 (Agent Roster Recommendation) explicitly answers "No" with rationale and a knowledge distribution table | COVERED |
+| Correct the bias in a meaningful way | Sections 2 and 4 provide prioritized changes across iac-minion, margo, and delegation table | COVERED |
+| Find the right entry point (CLAUDE.md? lucy?) | Section 2 Priority 4 recommends target project CLAUDE.md as the primary entry point; Section 8 ("What NOT to Do") explicitly rules out despicable-agents' own CLAUDE.md | COVERED |
+
+No stated requirements are unaddressed. No orphaned plan elements lack traceability to a stated requirement.
+
+---
+
+## Drift Assessment
+
+**Scope creep check**: The synthesis includes an implementation roadmap (Section 7, Phases A-E). This is marginally beyond "advisory-only" but is clearly labeled as conditional ("If the user decides to act") and provides actionable structure without executing anything. This is reasonable advisory content, not scope creep.
+
+**Over-engineering check**: The 5-level escalation ladder (Section 4) and technology maturity table (Section 4, gru's assessment) are detailed but directly answer the user's question about "what should greenfield defaults look like." They are analytical depth, not unnecessary complexity.
+
+**Feature substitution check**: None detected. The synthesis answers exactly the four questions the user posed (bias location, entry point, agent roster, greenfield defaults).
+
+**Gold-plating check**: Section 5 (Conflict Resolution) resolves three minor disagreements between specialists. This is appropriate synthesis work, not gold-plating.
+
+---
+
+## Convention Compliance
+
+### Publishability (Apache 2.0)
+
+The synthesis correctly identifies and enforces the publishability constraint throughout:
+
+- Section 2, Priority 1: iac-minion gains serverless *capability* (knowledge), not *opinion* (default preference). Verified in the proposed spec changes -- they add knowledge areas, not directives.
+- Section 2, Priority 2: margo gains operational complexity *detection*, not infrastructure *preference*. The "Infrastructure Over-Engineering" pattern is framed as a simplicity test, not a serverless advocacy position.
+- Section 2, Priority 4: The "serverless-first" preference is explicitly routed to target project CLAUDE.md, not the published agent system.
+- Section 8 ("What NOT to Do") row 2: Explicitly prohibits adding the preference to despicable-agents' own CLAUDE.md.
+- Section 6, Risk 4: Directly addresses publishability with mitigation.
+
+No publishability violations found.
+
+### CLAUDE.md Hierarchy Compliance
+
+The layered approach (target project CLAUDE.md for preference, agent specs for capability, delegation table for routing) is consistent with the existing CLAUDE.md hierarchy documented in the project. The synthesis correctly identifies that despicable-agents' CLAUDE.md governs agent development, not target project behavior.
+
+### the-plan.md Constraints
+
+The synthesis does not propose modifying `the-plan.md` directly -- it recommends spec changes that would require human approval (Section 7, Phase A: "Requires human approval since the-plan.md is human-edited"). This respects the CLAUDE.md rule "Do NOT modify the-plan.md unless you are the human owner or the human owner approves."
+
+### Existing Convention Patterns
+
+The proposed changes follow established patterns:
+- Spec version bumps (iac-minion 1.0 -> 1.1, margo 1.0 -> 1.1) follow the versioning convention in `the-plan.md`.
+- The CLAUDE.md template example follows the same style as the existing "prefer lightweight, vanilla solutions" directive.
+- Delegation table additions follow the existing table format with Primary/Supporting columns.
+
+---
+
+## One Minor Observation (Non-Blocking)
+
+Section 2, Priority 2, item 2 proposes adding specific platform names to margo's Boring Technology section ("AWS Lambda (2014), Cloudflare Workers (2018), and Vercel (2020)"). This is borderline for a generic simplicity enforcer -- margo currently names no specific technologies in the Boring Technology section. The proposed text is factual and non-opinionated, so it does not violate publishability, but it does shift margo from principle-based ("choose boring technology") toward example-based ("these specific platforms are boring"). This is a stylistic choice, not a convention violation.
+
+---
+
+## Summary
+
+The synthesis faithfully answers the user's four questions without scope expansion. The recommended entry points are consistent with existing project conventions. Publishability is preserved throughout. No goal drift detected. Line number references to agent files are verified accurate. The advisory stays within its stated scope of analysis and recommendations without executing changes.

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-margo-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-margo-prompt.md
@@ -1,0 +1,23 @@
+You are reviewing a delegation plan before execution begins.
+Your role: identify gaps, risks, or concerns from your domain.
+
+## Delegation Plan
+Read the full plan from: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase3-synthesis.md
+
+## Your Review Focus
+Simplicity and YAGNI review of the proposed changes:
+- Are any of the recommended changes over-engineered?
+- Is the 5-level escalation path too complex? Could it be simpler?
+- Does the advisory introduce unnecessary abstractions or frameworks?
+- Are there recommendations that could be consolidated or dropped?
+- Is the implementation roadmap appropriately scoped or does it expand beyond what was asked?
+
+## Instructions
+Return exactly one verdict:
+- APPROVE: No concerns from your domain.
+- ADVISE: <list specific non-blocking warnings>
+- BLOCK: <describe the blocking issue and what must change>
+
+Write your verdict to: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase3.5-margo.md
+
+Be concise. Only flag issues within your domain expertise.

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-margo.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-margo.md
@@ -1,0 +1,61 @@
+# Phase 3.5 Review: margo (Simplicity / YAGNI / KISS)
+
+## Verdict: ADVISE
+
+The synthesis is well-scoped and directly addresses the original question. The core diagnosis is correct: the system has a structural anti-serverless bias through compounding omissions, and the three-gap analysis is sound. No new agent, no new framework, no new abstraction -- expanding existing agent knowledge is the right call. That said, I have four specific concerns about creeping complexity within the advisory itself.
+
+---
+
+### 1. The 5-Level Escalation Ladder Is Over-Specified for an Advisory
+
+Section 4 introduces a 5-level escalation ladder (Levels 0-4) with two detailed tables: the levels themselves and a separate escalation triggers table with seven rows of specific thresholds ($500/month, $5k/month, 30s execution, etc.).
+
+This is a framework being designed before the second use case exists. The advisory was asked to **correct a bias**, not to build a deployment decision framework with cost thresholds. A simpler formulation would be: "Start with the simplest deployment that meets requirements. Escalate to containers or self-managed infrastructure only when a specific constraint demands it." That is one sentence. The detailed escalation triggers and cost thresholds belong in iac-minion's RESEARCH.md if and when someone actually builds this into the agent -- not in the advisory synthesis.
+
+**Risk**: If this ladder gets encoded into iac-minion's AGENT.md as-is, it becomes a rigid framework that must be maintained as platforms and pricing change. The specific dollar thresholds ($500, $5k) will be stale within a year.
+
+**Recommendation**: Keep the principle ("start simple, escalate on constraint"). Move the specific levels and triggers to iac-minion research material, not to the advisory's core recommendations.
+
+### 2. Four Delegation Table Rows Where One or Two Suffice
+
+Section 2, Priority 3 proposes adding four new delegation table rows:
+
+1. Deployment strategy selection
+2. Serverless platform deployment (Vercel, Cloudflare Pages, Netlify)
+3. Serverless compute provisioning (Lambda, Cloud Functions)
+4. Serverless-to-server migration
+
+The original problem is that "there is no row for serverless." The fix is to add a row for serverless. Adding four rows -- including one for a migration path nobody has needed yet (serverless-to-server migration) -- is scope creep.
+
+**Recommendation**: Two rows at most: "Deployment strategy selection" (iac-minion primary, devx-minion supporting) and "Serverless deployment" (iac-minion primary, edge-minion supporting). The distinction between "serverless platform deployment" and "serverless compute provisioning" is premature -- it splits a category before the routing has been tested once. The migration row is pure YAGNI.
+
+### 3. Technology Maturity Table in the Advisory Is Out of Scope
+
+Section 4 includes a technology maturity table rating five platforms (Lambda, Workers, Vercel, Netlify, Deno Deploy) with ring classification, lock-in risk, and best-use-case descriptions. This is gru's domain and belongs in gru's technology radar, not in the synthesis. Including it here makes the advisory responsible for maintaining platform assessments that will drift.
+
+**Recommendation**: Reference gru's assessment ("gru classifies Lambda and Workers as ADOPT, Vercel and Netlify as TRIAL") without reproducing the full table. The table lives in gru's knowledge, not in the advisory deliverable.
+
+### 4. Phase E Verification Is Premature
+
+The implementation roadmap includes "Phase E: Verification" with two dry-run test scenarios. This is good engineering practice for an execution plan, but this is an advisory. The user asked for a report, not an execution plan with test harnesses. If the user decides to act on the advisory, the execution plan (with its own verification) would be a separate nefario orchestration.
+
+**Recommendation**: Drop Phase E from the advisory. Mention that verification should be part of any execution plan that follows. Do not design the test scenarios before the changes exist.
+
+---
+
+### What the Advisory Gets Right
+
+- **No 28th agent** -- correct call, well-justified.
+- **Three-gap root cause** -- accurate, specific, and actionable.
+- **CLAUDE.md as the preference layer** -- right abstraction boundary. Published agents gain capability, not opinion.
+- **Conflict resolution** -- the three conflicts are resolved cleanly with clear rationale.
+- **Section 8 "What NOT to Do"** -- this is the best section in the document. It prevents over-correction.
+- **margo complexity budget split** (self-managed 8, managed 3) -- correctly reframes cost around operational burden rather than novelty. I accept this calibration change.
+- **Boring Technology update** -- serverless platforms are boring technology. Adding them to the examples is correct.
+- **Infrastructure Over-Engineering detection** -- this is a simplicity test, not an infrastructure preference. It belongs in margo's remit.
+
+### Summary
+
+The advisory's core recommendations (Priorities 1-4) are sound and proportional to the problem. The complexity creep is in the details: over-specified escalation frameworks, too many delegation table rows, reproduced technology assessments, and premature verification design. Trim these and the advisory is tight.
+
+None of these concerns are blocking -- the core recommendations can be executed without adopting the over-specified details. Hence ADVISE, not BLOCK.

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-security-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-security-minion-prompt.md
@@ -1,0 +1,22 @@
+You are reviewing a delegation plan before execution begins.
+Your role: identify gaps, risks, or concerns from your domain.
+
+## Delegation Plan
+Read the full plan from: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase3-synthesis.md
+
+## Your Review Focus
+Security implications of the serverless bias correction advisory. Consider:
+- Does the advisory adequately address the security implications of serverless-first defaults?
+- Serverless security model (shared responsibility, function-level permissions, secrets management)
+- Vendor lock-in as a security consideration
+- Are there security anti-patterns that could emerge from a "serverless-first" default?
+
+## Instructions
+Return exactly one verdict:
+- APPROVE: No concerns from your domain.
+- ADVISE: <list specific non-blocking warnings>
+- BLOCK: <describe the blocking issue and what must change>
+
+Write your verdict to: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase3.5-security-minion.md
+
+Be concise. Only flag issues within your domain expertise.

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-security-minion.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-security-minion.md
@@ -1,0 +1,45 @@
+# Phase 3.5 Review: security-minion
+
+## Verdict: ADVISE
+
+The synthesis is well-structured and the bias diagnosis is sound. The proposed changes do not introduce security vulnerabilities into the agent system itself. However, the advisory has a meaningful gap: it treats serverless as a deployment and simplicity question without addressing the distinct security model that serverless introduces. Three specific warnings follow.
+
+### Warning 1: iac-minion's serverless knowledge must include serverless security patterns
+
+The proposed iac-minion expansion (Section 2, Priority 1) covers deployment strategy selection, platform config, and cost modeling -- but says nothing about security. Serverless has a fundamentally different security model from server-based infrastructure:
+
+- **Shared responsibility shifts upward**: The cloud provider owns OS patching, runtime updates, and network segmentation. The developer owns function-level IAM, input validation, and secrets management. Teams accustomed to server-based security controls (firewalls, host-based IDS, network ACLs) lose those tools entirely.
+- **Function-level permissions**: Each Lambda/Worker/serverless function should have its own least-privilege IAM role. The most common anti-pattern is a single overprivileged role shared across all functions. iac-minion must know to recommend per-function roles.
+- **Secrets management changes**: No `.env` files on disk. Secrets go through platform-specific stores (AWS Secrets Manager, Vercel Environment Variables with encryption, Cloudflare Workers Secrets). The iac-minion triage tree should include "how does this platform handle secrets?" as a standard evaluation criterion.
+- **Cold start injection surface**: Initialization code runs once per cold start and is cached across invocations. State leakage between invocations (global variables, `/tmp` contents on Lambda) is a real attack vector.
+- **Event injection**: Serverless functions are triggered by events (HTTP, queue messages, storage events, cron). Each event source is an input vector. The function must validate the event schema, not just the HTTP request body.
+
+**Recommendation**: Add "Serverless Security Considerations" as a subsection under the proposed "Serverless Deployment Patterns" section in iac-minion's knowledge. This does not need to be deep -- security-minion handles deep security review -- but iac-minion must produce deployment recommendations that are secure by default.
+
+### Warning 2: Vendor lock-in is also a security risk, not just a cost/portability risk
+
+Section 6, Risk 2 frames vendor lock-in purely as a cost and portability concern. It is also a security concern:
+
+- **Single point of trust**: A compromised serverless platform (credential breach, supply chain attack on the runtime) exposes all functions simultaneously. With self-managed infrastructure, you control the blast radius.
+- **Opaque runtime environment**: You cannot audit the Lambda execution environment, inspect the Workers V8 isolate, or verify what runs alongside your function. This is a trust decision, not just a deployment decision.
+- **Platform-specific vulnerabilities**: CVEs in serverless runtimes (e.g., Lambda container escape, Workers isolate bypass) are outside your control to patch. You depend on vendor response time.
+- **Data residency and exfiltration**: Serverless data services (D1, DynamoDB, Vercel KV) may replicate data across regions in ways that conflict with data residency requirements. This is a GDPR and compliance concern, not just a preference.
+
+**Recommendation**: Add a bullet to Risk 2's mitigation acknowledging that vendor lock-in carries security implications (single point of trust, opaque runtime, dependency on vendor patching cadence). The portability assessment that iac-minion produces should include a "security trust" dimension alongside cost and portability.
+
+### Warning 3: The escalation ladder should include a security trigger
+
+The escalation triggers table (Section 4) lists performance, cost, and compatibility triggers for moving between levels. It omits security triggers:
+
+- **Compliance-mandated audit trails** that serverless logging does not satisfy --> escalate to Level 3-4
+- **Need for WAF, custom network policies, or mTLS** that the serverless platform does not support natively --> escalate
+- **Data classification requiring infrastructure-level encryption controls** (BYOK, HSM integration) --> escalate
+- **Incident response requirements** where you need to inspect the host, capture memory, or run forensics --> escalate (impossible on serverless)
+
+The table already includes "Data residency / compliance mandates" at Level 2-3 to Level 4, which partially covers this. But security escalation triggers deserve explicit enumeration so iac-minion does not recommend serverless for workloads with security requirements that serverless cannot satisfy.
+
+**Recommendation**: Add 1-2 security-specific rows to the escalation triggers table: "Compliance-mandated infrastructure audit/forensics" and "Custom network security controls (WAF, mTLS, network segmentation)" as triggers to Level 3-4.
+
+### Summary
+
+None of these warnings are blocking. The advisory correctly identifies the bias and proposes sound structural fixes. The security gap is that serverless is treated as a pure simplicity/cost/DX decision without acknowledging its distinct security model. Adding serverless security patterns to iac-minion's expanded knowledge, acknowledging vendor lock-in as a security risk, and including security escalation triggers would make the advisory complete from a security perspective.

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-test-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-test-minion-prompt.md
@@ -1,0 +1,22 @@
+You are reviewing a delegation plan before execution begins.
+Your role: identify gaps, risks, or concerns from your domain.
+
+## Delegation Plan
+Read the full plan from: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase3-synthesis.md
+
+## Your Review Focus
+Testing implications of the serverless bias correction advisory. Consider:
+- Does the advisory consider testability of serverless deployments?
+- Local testing strategies for serverless functions
+- Integration testing challenges with serverless architectures
+- Should testing considerations be part of the iac-minion's deployment strategy triage?
+
+## Instructions
+Return exactly one verdict:
+- APPROVE: No concerns from your domain.
+- ADVISE: <list specific non-blocking warnings>
+- BLOCK: <describe the blocking issue and what must change>
+
+Write your verdict to: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase3.5-test-minion.md
+
+Be concise. Only flag issues within your domain expertise.

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-test-minion.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-test-minion.md
@@ -1,0 +1,27 @@
+# Phase 3.5 Review: test-minion
+
+## Verdict: ADVISE
+
+The advisory is well-structured and the four-priority plan is sound. No blocking issues. Two non-blocking concerns from a testing perspective:
+
+### 1. Phase E Verification Is Underspecified and Unrepeatable
+
+Section 7, Phase E describes two dry-run tests ("deploy a simple API" greenfield scenario and a WebSocket counter-test). These are manual, narrative-level checks with no defined pass/fail criteria. They verify the happy path once but provide no regression safety. When iac-minion or margo are rebuilt in the future (spec bumps, knowledge updates), these checks will not be re-run because they exist only as prose in an advisory document.
+
+**Recommendation**: When Phase E is executed, capture the dry-run scenarios as lightweight, documented test cases (even if they remain manual) with explicit expected outcomes. For example:
+
+- Input: greenfield project, serverless-first CLAUDE.md, "deploy a 3-endpoint API with PostgreSQL"
+- Expected: iac-minion recommends Level 2 (serverless app), delegation routes through "Deployment strategy selection" row, margo does not flag complexity
+- Failure: iac-minion proposes Docker/Terraform, or delegation routes through generic "Infrastructure provisioning" row
+
+This makes re-verification possible after future agent rebuilds.
+
+### 2. Testability of the Triage Decision Tree Is Not Addressed
+
+The plan introduces a deployment strategy triage decision tree as a new first step in iac-minion's working pattern. Decision trees are excellent candidates for structured testing -- each branch can be validated with a known input/output pair. The advisory does not mention how to verify the tree produces correct recommendations across its decision space (all-NO path, single-YES paths, multiple-YES paths, edge cases like "WebSockets but low traffic").
+
+**Recommendation**: When building the triage decision tree into iac-minion's AGENT.md, include 3-5 worked examples (scenario + recommended level + rationale) inline in the agent knowledge. These serve as both documentation and implicit test cases that make the decision tree auditable. They also give iac-minion calibration anchors when applying the tree to novel inputs.
+
+### Not In Scope (Acknowledged)
+
+The advisory is about correcting bias in agent knowledge and routing, not about testing serverless deployments themselves. The question of "how should test-minion advise on testing serverless functions" (local emulation, integration testing with cloud services, cold start testing) is a separate concern that would arise during actual project execution, not during this advisory implementation. No gap here.

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-ux-strategy-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-ux-strategy-minion-prompt.md
@@ -1,0 +1,22 @@
+You are reviewing a delegation plan before execution begins.
+Your role: evaluate journey coherence, cognitive load, and simplification
+opportunities across the plan.
+
+## Delegation Plan
+Read the full plan from: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase3-synthesis.md
+
+## Your Review Focus
+1. Journey coherence: Do the recommended changes form a coherent experience for developers using the agent system? Is the escalation path intuitive?
+2. Cognitive load: Will the changes simplify or complicate the developer's decision-making when choosing a deployment strategy?
+3. Simplification: Can any recommended changes be combined or simplified?
+4. User jobs-to-be-done: Does each recommendation serve a real developer need?
+
+## Instructions
+Return exactly one verdict:
+- APPROVE: No concerns from your domain.
+- ADVISE: <list specific non-blocking warnings>
+- BLOCK: <describe the blocking issue and what must change>
+
+Write your verdict to: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-h3BN8s/serverless-bias-correction/phase3.5-ux-strategy-minion.md
+
+Be concise. Only flag issues within your domain expertise.

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-ux-strategy-minion.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/phase3.5-ux-strategy-minion.md
@@ -1,0 +1,23 @@
+# Phase 3.5 Review: UX Strategy
+
+## Verdict: APPROVE
+
+The synthesis plan is well-structured from a developer experience perspective. The core insight -- that three independent gaps compound to produce a systematic bias -- is a textbook example of a broken user journey where each step is locally reasonable but the end-to-end outcome fails the user's job-to-be-done.
+
+## Positive Assessment
+
+**Journey coherence is strong.** The 5-level escalation ladder (Section 4) is the plan's best UX contribution. It transforms an implicit, invisible decision ("you get servers because that is all we know") into an explicit, scannable decision framework with clear escalation triggers. This is progressive disclosure applied to infrastructure: start simple, add complexity only when a named constraint demands it. The developer's mental model shifts from "how do I configure infrastructure?" to "do I need infrastructure?" -- a far better framing.
+
+**Cognitive load is reduced, not increased.** Counter-intuitively, adding serverless knowledge to iac-minion reduces the developer's cognitive burden. Today, if a developer suspects serverless is appropriate, they must override the system's recommendation and bring their own knowledge. After this change, the system does the triage. The decision tree (persistent connections? long-running processes? compliance? cost at scale?) offloads the evaluation from the developer's working memory to the agent's knowledge.
+
+**The CLAUDE.md layering is correct.** Placing "serverless-first" preference in each target project's CLAUDE.md rather than in published agents is the right separation. It follows the same progressive disclosure pattern the codebase already uses for technology preferences. Developers who want server-first defaults simply omit the directive. No new concept to learn.
+
+**The "What NOT to Do" table (Section 8) is unusually valuable.** Explicitly documenting rejected alternatives prevents future re-litigation and reduces the cognitive cost of understanding why the system works the way it does.
+
+## Minor Observations (Non-blocking)
+
+1. **Delegation table expansion**: Four new rows is reasonable. The distinction between "serverless platform deployment" and "serverless compute provisioning" may be too granular for nefario's routing -- a developer asking "deploy my API" will not think in those categories. Monitor whether nefario routes correctly in practice, or whether collapsing to two rows (deployment strategy selection + serverless deployment) would reduce routing ambiguity.
+
+2. **Margo's complexity budget numbers**: The shift from a flat 5 to an 8/3 split is directionally correct. The exact numbers are less important than the principle (operational burden matters more than novelty). Expect these to need calibration over time. The risk is developers trying to game the score -- keep the budget as a heuristic guide, not a calculator.
+
+No blocking issues. The plan serves the developer's core job ("deploy my project with appropriate infrastructure") with less cognitive effort than the current system requires.

--- a/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-110715-serverless-bias-correction/prompt.md
@@ -1,0 +1,3 @@
+Advisory-only request. Create a meaningful report with the team to consult on the following question, don't act. No execution or post-processing. Use opus for all agents involved.
+
+Question: When starting greenfield, the system thinks serverless is complicated and flags it as overengineering / YAGNI / anti-KISS, but that's a wrong bias. Serverless is super simple. Maybe we need a serverless agent in the roster? At a minimum, we must correct the bias in a meaningful way and find the right entry point for that (CLAUDE.md? lucy?).


### PR DESCRIPTION
## Summary

- Adds advisory report from nefario orchestration analyzing and correcting anti-serverless bias in the agent system
- Five specialists (iac-minion, margo, gru, lucy, devx-minion) confirmed the bias and recommended expanding existing agents rather than creating a new serverless agent
- Advisory only — no code changes, just the report artifacts (26 files)

## Test plan

- [x] Report follows v3 template format
- [x] No code changes to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)