### PR TITLE
docs: add nefario advisory report for GH about section proposal

### DIFF
--- a/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal.md
+++ b/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal.md
@@ -1,0 +1,211 @@
+---
+type: nefario-report
+version: 3
+date: "2026-02-13"
+time: "11:46:22"
+task: "Propose description, website, and topics for the GitHub About section"
+mode: advisory
+agents-involved: [product-marketing-minion, seo-minion, ux-strategy-minion, lucy, nefario]
+task-count: 0
+gate-count: 0
+outcome: completed
+---
+
+# Propose description, website, and topics for the GitHub About section
+
+## Summary
+
+Four specialists analyzed the despicable-agents GitHub About section (currently empty) across product positioning, SEO discoverability, UX strategy, and project consistency. The team reached strong consensus: lead with "specialist agent team for Claude Code," highlight governance gates as the primary differentiator, use 8 curated topics anchored by `claude-code` and `ai-agents`, and leave the website field blank. Confidence is HIGH because all recommendations are grounded in the project's existing canonical language and the decision is easily reversible.
+
+## Original Prompt
+
+> Propose description, website, topics for the GH about section of the repo.
+
+## Key Design Decisions
+
+#### Description length: short (106 chars) vs. long (299 chars)
+
+**Rationale**:
+- The short version survives GitHub's truncation in all display contexts (search results, sidebar, pinned repos, org pages)
+- The README already handles the longer pitch one click away
+- The 106-char version is complete: it answers what, where, how many, and why-different
+
+**Alternatives Rejected**:
+- 299-char version: adds domain list, reviewer count, and install convenience, but this detail only displays on the repo page sidebar, not in search results. Viable alternative if maximum information density is preferred.
+
+#### Topic count: 8 topics
+
+**Rationale**:
+- 8 is the balance point between lucy's conservative 5-7 (accuracy-first) and seo-minion's expansive 10 (coverage-first)
+- Every included topic is verified-accurate against the canonical docs
+- Below the 20-topic GitHub maximum, above the minimum for adequate discovery
+
+**Alternatives Rejected**:
+- 5-7 topics: misses ecosystem anchors (`anthropic`, `developer-tools`) that cost nothing to include
+- 10 topics: includes `prompt-engineering` (attracts wrong audience) and `agent-teams` (not yet established)
+
+### Conflict Resolutions
+
+**Description length**: ux-strategy-minion (106 chars) vs. product-marketing-minion (299 chars). Resolved in favor of short -- survives truncation everywhere, matches README's concise style. Long version preserved as explicit alternative.
+
+**`claude` topic inclusion**: seo-minion excluded (redundant with `claude-code`), product-marketing and ux-strategy included. Resolved in favor of inclusion -- 6,927 repos, zero cost, exact target audience.
+
+**`prompt-engineering` topic**: seo-minion included, others excluded. Resolved in favor of exclusion -- while technically accurate, the topic attracts developers seeking prompt templates, not an agent team.
+
+## Phases
+
+### Phase 1: Meta-Plan
+
+Nefario identified three specialists for planning: product-marketing-minion (value proposition and competitive positioning), seo-minion (GitHub topic strategy), and ux-strategy-minion (first-impression information hierarchy). Lucy was added at the user's request to verify consistency with the project's established identity. No external skills were relevant to this metadata task.
+
+### Phase 2: Specialist Planning
+
+**product-marketing-minion** analyzed the competitive landscape (wshobson/agents, ruvnet/claude-flow, VoltAgent) and identified governance gates as an uncontested positioning axis. Proposed three candidate descriptions with trade-off analysis. Recommended "fun names, serious descriptions" as the tone principle.
+
+**seo-minion** researched 12 GitHub topic ecosystems, examining repository counts and usage patterns across 6 comparable repos. Proposed 10 topics in three tiers (platform identity, domain descriptors, ecosystem anchors). Deliberately excluded `llm` (too broad at 39k repos), `framework` (inaccurate), and `autonomous-agents` (misleading).
+
+**ux-strategy-minion** grounded the description in cognitive science -- the satisficing two-stage pattern where developers pattern-match in <2 seconds then assess value. Recommended leading with WHAT IT IS for fastest categorization. Analyzed GitHub truncation thresholds and determined the first ~100 characters must be self-sufficient.
+
+**lucy** verified strong internal consistency across all canonical documents (CLAUDE.md, README.md, the-plan.md, architecture.md). The phrase "specialist agent team for Claude Code" appears in nearly identical form across all four. Provided an accuracy audit classifying potential topics as Accurate, Borderline, or Avoid.
+
+### Phase 3: Synthesis
+
+Nefario synthesized contributions into a unified advisory report. Strong consensus existed across all four specialists on the core recommendations. Two conflicts required resolution: description length (short vs. long) and topic composition (conservative vs. expansive). Both were resolved with clear rationale and the minority positions preserved as alternatives.
+
+### Phase 3.5: Architecture Review
+
+Skipped (advisory-only orchestration).
+
+### Phase 4: Execution
+
+Skipped (advisory-only orchestration).
+
+### Phase 5: Code Review
+
+Skipped (advisory-only orchestration).
+
+### Phase 6: Test Execution
+
+Skipped (advisory-only orchestration).
+
+### Phase 7: Deployment
+
+Skipped (advisory-only orchestration).
+
+### Phase 8: Documentation
+
+Skipped (advisory-only orchestration).
+
+## Agent Contributions
+
+<details>
+<summary>Agent Contributions (4 planning)</summary>
+
+### Planning
+
+**product-marketing-minion**: Competitive analysis showing governance gates as uncontested differentiator. Three candidate descriptions with trade-off analysis. "Fun names, serious descriptions" tone principle.
+- Adopted: governance-first positioning, 106-char description structure, topic recommendations for `claude-code`, `ai-agents`, `claude`, `developer-tools`
+- Risks flagged: agent count staleness, quantity comparison with competitors claiming 100+ agents
+
+**seo-minion**: Most detailed topic ecosystem research with repository counts for every relevant topic. Three-tier topic strategy (platform identity, domain descriptors, ecosystem anchors). Competitive topic analysis across 6 comparable repos.
+- Adopted: tiered topic strategy, `claude-agents` early-presence play, `agent-orchestration` niche targeting, exclusion of `llm` and `framework`
+- Risks flagged: emerging topic instability, quarterly review cadence recommendation
+
+**ux-strategy-minion**: Cognitive science grounding for description structure (satisficing pattern). Truncation threshold analysis across GitHub display contexts. Theming impact assessment.
+- Adopted: lead with WHAT IT IS, 106-char length target, "let name carry personality, description carry information"
+- Risks flagged: description truncation varies, competitive positioning against quantity-claiming repos
+
+**lucy**: Consistency audit across all canonical documents. Topic accuracy classification (Accurate/Borderline/Avoid). Identified that "specialist agent team for Claude Code" appears in all canonical docs.
+- Adopted: reuse existing language, avoid new terminology, 5 "Avoid" topic exclusions (`framework`, `autonomous-agents`, `automation`, `mcp`, `ai-framework`)
+- Risks flagged: agent count maintenance burden (accepted -- matches existing convention)
+
+</details>
+
+## Team Recommendation
+
+**Use the short description (106 chars), leave website blank, apply 8 topics.**
+
+### Consensus
+
+| Position | Agents | Strength |
+|----------|--------|----------|
+| Lead with "specialist agent team for Claude Code" | All four | Unanimous |
+| Governance gates as primary differentiator | All four | Unanimous |
+| Leave website blank | All four | Unanimous |
+| Fun names, serious descriptions | product-marketing, ux-strategy, lucy | Strong |
+| Include exact count "27" | All four | Unanimous |
+| Exclude `framework`, `autonomous-agents`, `automation` | All four | Unanimous |
+
+### Recommended Values
+
+**Description** (106 chars):
+
+> Specialist agent team for Claude Code -- 27 domain experts with orchestration and governance gates.
+
+**Alternative description** (299 chars):
+
+> 27 specialist agents for Claude Code with phased orchestration and governance gates. Domain experts for security, testing, API design, infrastructure, and more -- each with strict boundaries. Five mandatory reviewers check every plan before code runs. Install once, use in any project.
+
+**Website**: Leave blank.
+
+**Topics** (8): `claude-code`, `ai-agents`, `agent-orchestration`, `claude`, `multi-agent`, `claude-agents`, `developer-tools`, `anthropic`
+
+### Implementation
+
+```bash
+gh repo edit --description "Specialist agent team for Claude Code -- 27 domain experts with orchestration and governance gates."
+gh repo edit --add-topic claude-code --add-topic ai-agents --add-topic agent-orchestration --add-topic claude --add-topic multi-agent --add-topic claude-agents --add-topic developer-tools --add-topic anthropic
+```
+
+### When to Revisit
+
+1. Agent count changes (agents added or removed from the roster)
+2. A dedicated documentation site or landing page is created (add as website URL)
+3. GitHub introduces new discovery mechanisms or changes topic behavior
+4. `claude-agents` or `agent-orchestration` topic ecosystems stagnate after 6 months (swap for alternatives)
+5. Anthropic introduces official terminology for Claude Code agent collections
+
+### Strongest Arguments
+
+**For short description (106 chars)** (adopted):
+
+| Argument | Agent |
+|----------|-------|
+| Survives truncation in all GitHub display contexts | ux-strategy-minion |
+| README handles the longer pitch one click away | ux-strategy-minion |
+| Matches existing project style (concise, functional) | lucy |
+
+**For long description (299 chars)** (not adopted, but preserved):
+
+| Argument | Agent |
+|----------|-------|
+| Lists concrete domains (security, testing, API) for pattern-matching | product-marketing-minion |
+| "Five mandatory reviewers" is the strongest trust signal | product-marketing-minion |
+| More search keyword surface area | seo-minion |
+
+## Working Files
+
+<details>
+<summary>Working files (13 files)</summary>
+
+Companion directory: [2026-02-13-114622-gh-about-section-proposal/](./2026-02-13-114622-gh-about-section-proposal/)
+
+- [Original Prompt](./2026-02-13-114622-gh-about-section-proposal/prompt.md)
+
+**Outputs**
+- [Phase 1: Meta-plan](./2026-02-13-114622-gh-about-section-proposal/phase1-metaplan.md)
+- [Phase 2: product-marketing-minion](./2026-02-13-114622-gh-about-section-proposal/phase2-product-marketing-minion.md)
+- [Phase 2: seo-minion](./2026-02-13-114622-gh-about-section-proposal/phase2-seo-minion.md)
+- [Phase 2: ux-strategy-minion](./2026-02-13-114622-gh-about-section-proposal/phase2-ux-strategy-minion.md)
+- [Phase 2: lucy](./2026-02-13-114622-gh-about-section-proposal/phase2-lucy.md)
+- [Phase 3: Synthesis](./2026-02-13-114622-gh-about-section-proposal/phase3-synthesis.md)
+
+**Prompts**
+- [Phase 1: Meta-plan prompt](./2026-02-13-114622-gh-about-section-proposal/phase1-metaplan-prompt.md)
+- [Phase 2: product-marketing-minion prompt](./2026-02-13-114622-gh-about-section-proposal/phase2-product-marketing-minion-prompt.md)
+- [Phase 2: seo-minion prompt](./2026-02-13-114622-gh-about-section-proposal/phase2-seo-minion-prompt.md)
+- [Phase 2: ux-strategy-minion prompt](./2026-02-13-114622-gh-about-section-proposal/phase2-ux-strategy-minion-prompt.md)
+- [Phase 2: lucy prompt](./2026-02-13-114622-gh-about-section-proposal/phase2-lucy-prompt.md)
+- [Phase 3: Synthesis prompt](./2026-02-13-114622-gh-about-section-proposal/phase3-synthesis-prompt.md)
+
+</details>

--- a/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase1-metaplan-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase1-metaplan-prompt.md
@@ -1,0 +1,49 @@
+MODE: META-PLAN
+
+You are creating a meta-plan -- a plan for who should help plan.
+
+## Task
+
+Propose description, website, and topics for the GitHub "About" section of the despicable-agents repo.
+
+Current state: The About section is completely empty (no description, no website URL, no topics).
+
+Repo context:
+- Name: despicable-agents
+- Owner: benpeter
+- URL: https://github.com/benpeter/despicable-agents
+- License: Apache 2.0
+- Primary language: Shell
+- Content: 27 specialist agents for Claude Code, organized as team with orchestrator (nefario), governance (lucy, margo), and 23 domain-specialist minions
+- Key features: phased orchestration, research-backed domain experts, built-in governance gates, execution reports
+- Built on Claude Code Agent Teams
+
+The GitHub About section has three fields:
+1. **Description** -- short text (max ~350 chars) shown below repo name
+2. **Website** -- URL shown as link
+3. **Topics** -- tags for discoverability (lowercase, hyphenated)
+
+This is an advisory-only orchestration. Focus on analysis, trade-offs, and recommendations.
+
+## Working Directory
+
+/Users/ben/github/benpeter/2despicable/2
+
+## External Skill Discovery
+
+Before analyzing the task, scan for project-local skills in .claude/skills/ and .skills/.
+
+## Instructions
+
+1. Read relevant files to understand the codebase context
+2. Discover external skills:
+   a. Scan .claude/skills/ and .skills/ in the working directory for SKILL.md files
+   b. Read frontmatter (name, description) for each discovered skill
+   c. For skills whose description matches the task domain, classify as ORCHESTRATION or LEAF
+   d. Check the project's CLAUDE.md for explicit skill preferences
+   e. Include discovered skills in your meta-plan output
+3. Analyze the task against your delegation table
+4. Identify which specialists should be CONSULTED FOR PLANNING (not execution -- planning). These are agents whose domain expertise is needed to create a good recommendation.
+5. For each specialist, write a specific planning question that draws on their unique expertise.
+6. Return the meta-plan in the structured format.
+7. Write your complete meta-plan to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-q2AEa6/gh-about-section-proposal/phase1-metaplan.md

--- a/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase1-metaplan.md
+++ b/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase1-metaplan.md
@@ -1,0 +1,75 @@
+# Meta-Plan: GitHub About Section Proposal
+
+## Task Summary
+
+Propose description, website URL, and topics for the despicable-agents GitHub
+repo About section, which is currently empty. This is an advisory task -- no
+code changes, purely recommendation and analysis.
+
+## Planning Consultations
+
+### Consultation 1: Product Positioning and Messaging
+
+- **Agent**: product-marketing-minion
+- **Planning question**: Given that despicable-agents is an open-source (Apache 2.0) specialist agent framework for Claude Code with 27 agents, phased orchestration, and built-in governance -- what description (max ~350 chars) best communicates the value proposition to developers discovering the repo on GitHub? Consider: what makes this different from other AI agent frameworks? What keywords should appear in the description for scanning readability? Should the tone lean technical/functional or slightly playful (given the Despicable Me naming)?
+- **Context to provide**: README.md content, architecture overview, the "What You Get" section listing key differentiators (phased orchestration, research-backed domain experts, governance gates, execution reports)
+- **Why this agent**: Product-marketing-minion specializes in positioning, feature messaging, and competitive differentiation. A GitHub description is a micro-positioning statement -- it needs to communicate value in one glance.
+
+### Consultation 2: Discoverability and Topic Strategy
+
+- **Agent**: seo-minion
+- **Planning question**: What GitHub topics maximize discoverability for this repo? Consider: (1) what terms developers search when looking for Claude Code extensions, AI agent frameworks, or multi-agent orchestration tools; (2) which existing GitHub topic ecosystems have active communities (e.g., `claude`, `anthropic`, `ai-agents`, `llm`); (3) the balance between broad topics (high traffic, low signal) and specific topics (low traffic, high relevance); (4) GitHub's topic limit and best practices for topic count. Research what topics competing/related repos use (e.g., claude-code tools, MCP servers, AI agent frameworks).
+- **Context to provide**: Repo metadata (language: Shell, license: Apache 2.0), key technology associations (Claude Code, Agent Teams, MCP), the project's domain (multi-agent orchestration, domain specialists, governance)
+- **Why this agent**: SEO-minion understands discoverability, keyword strategy, and how platform-specific metadata (GitHub topics) drives organic discovery. Topics are GitHub's equivalent of meta tags.
+
+### Consultation 3: Feature Naming and Value Proposition Clarity
+
+- **Agent**: ux-strategy-minion
+- **Planning question**: From a user journey perspective, a developer lands on this GitHub repo page and sees the About section first. What information hierarchy best serves the "should I care about this?" decision in 3 seconds? Should the description lead with what it IS (specialist agent team for Claude Code), what it DOES (orchestrated multi-agent execution with governance), or what PROBLEM it solves (complex tasks get decomposed across domain experts)? Does the Despicable Me theming help or hurt first-impression comprehension for developers who have never heard of this project?
+- **Context to provide**: README.md first screen, the examples section showing usage patterns, the install flow
+- **Why this agent**: UX-strategy-minion evaluates cognitive load and first-impression clarity. The About section is the repo's "above the fold" -- it must pass a snap judgment test.
+
+## Cross-Cutting Checklist
+
+- **Testing**: NOT included for planning. This is a metadata/content advisory task with no executable output.
+- **Security**: NOT included for planning. No code, no attack surface, no secrets. GitHub About fields are public metadata on an already-public repo.
+- **Usability -- Strategy**: INCLUDED (Consultation 3). The About section is a user-facing touchpoint that directly affects the "discover and evaluate" user journey.
+- **Usability -- Design**: NOT included for planning. No UI components or visual design involved -- GitHub renders the About section in a fixed layout.
+- **Documentation**: NOT included for planning. The About section is not documentation; it is metadata. software-docs-minion and user-docs-minion have no relevant planning input here, though their existing work (README, docs/) informs the content.
+- **Observability**: NOT included for planning. No runtime components.
+
+## Anticipated Approval Gates
+
+None anticipated. This is an advisory task -- the output is a recommendation, not an execution artifact. The user will decide what to set in the GitHub About section based on the advisory report.
+
+## Rationale
+
+Three specialists are consulted because the About section sits at the intersection of three concerns:
+
+1. **Messaging** (product-marketing-minion): The description is a positioning statement. Getting the value proposition wrong means developers scroll past.
+2. **Discoverability** (seo-minion): Topics are the primary mechanism for organic GitHub discovery. Wrong topics mean the right audience never finds the repo.
+3. **First-impression UX** (ux-strategy-minion): The About section is the first thing visitors see. Information hierarchy and cognitive load determine whether they read further.
+
+Agents NOT consulted and why:
+- **gru**: No technology evaluation needed. This is about presentation, not technical direction.
+- **software-docs-minion / user-docs-minion**: The existing README and docs are inputs, not outputs. No documentation is being produced.
+- **All development/infrastructure/security agents**: No code, infra, or security surface involved.
+
+## Scope
+
+**In scope**: Recommend specific text for the description field (~350 char max), a website URL (or recommendation to leave blank), and a curated list of GitHub topics with rationale for each.
+
+**Out of scope**: Modifying the README, changing repo settings beyond the About section, creating a project website, redesigning the repo structure.
+
+## External Skill Integration
+
+### Discovered Skills
+
+| Skill | Location | Classification | Domain | Recommendation |
+|-------|----------|---------------|--------|----------------|
+| despicable-lab | .claude/skills/despicable-lab/ | LEAF | Agent build/rebuild | Not relevant -- task does not involve agent regeneration |
+| despicable-statusline | .claude/skills/despicable-statusline/ | LEAF | Claude Code status line config | Not relevant -- task does not involve status line configuration |
+
+### Precedence Decisions
+
+No precedence conflicts. Neither discovered skill overlaps with the task domain (product messaging, discoverability, UX strategy).

--- a/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase2-lucy-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase2-lucy-prompt.md
@@ -1,0 +1,48 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet -- you are providing your domain expertise
+to help build a comprehensive recommendation.
+
+## Project Task
+
+Propose description, website, and topics for the GitHub "About" section of the despicable-agents repo. The About section is currently completely empty.
+
+## Your Planning Question
+
+Does the proposed About section content align with the project's established identity, conventions, and CLAUDE.md? Specifically: (1) Is the description consistent with how the project describes itself in CLAUDE.md, README, and the-plan.md? (2) Do proposed topics accurately reflect what the project IS (not aspirational features)? (3) Does the overall tone match the project's existing voice -- which balances technical precision with the playful Despicable Me naming? (4) Are there any contradictions between the About section content and the project's stated design principles (generic, publishable, composable, persistent learners)?
+
+## Context
+
+- Repo: https://github.com/benpeter/despicable-agents
+- CLAUDE.md describes: "Specialist agent team for Claude Code. 27 agents organized as Gru (boss), Nefario (orchestrator), Lucy and Margo (governance), and 23 domain-specialist minions."
+- Design principles from the-plan.md: generic domain specialists, publishable, composable, persistent learners
+- Engineering philosophy: Helix Manifesto -- YAGNI, KISS, lean and mean
+- License: Apache 2.0
+- Key rule: "No PII, no proprietary data -- agents must remain publishable"
+
+## Advisory Context
+
+This is an advisory-only orchestration. Your contribution will feed into a team recommendation, not an execution plan. Focus on analysis, trade-offs, and recommendations rather than implementation tasks.
+
+## Instructions
+
+1. Read CLAUDE.md, README.md, and the-plan.md to understand the project's self-description
+2. Evaluate consistency between the project's internal and external identity
+3. Flag any potential contradictions or misalignments
+4. Recommend how the About section should reflect the project's established voice
+5. Return your contribution in this format:
+
+## Domain Plan Contribution: lucy
+
+### Recommendations
+<your expert recommendations>
+
+### Proposed Tasks
+<specific deliverables for the advisory>
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+None (or explain why)
+
+7. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-q2AEa6/gh-about-section-proposal/phase2-lucy.md

--- a/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase2-lucy.md
+++ b/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase2-lucy.md
@@ -1,0 +1,115 @@
+## Domain Plan Contribution: lucy
+
+### Recommendations
+
+#### 1. Description: Consistency Check Against Canonical Sources
+
+The project describes itself with remarkable consistency across all canonical documents:
+
+| Source | Self-Description |
+|--------|-----------------|
+| **CLAUDE.md** (line 1-4) | "Specialist agent team for Claude Code. 27 agents organized as Gru (boss), Nefario (orchestrator), Lucy and Margo (governance), and 23 domain-specialist minions." |
+| **README.md** (line 6) | "Structured orchestration, domain specialists, and governance gates for Claude Code. Built on Agent Teams. 27 agents, 2 skills, available in every session after a one-time install." |
+| **architecture.md** (line 3) | "despicable-agents is a specialist agent team for Claude Code: 27 agents organized into a four-tier hierarchy." |
+
+The GitHub About description field allows roughly 350 characters. The description must be consistent with this established self-description. Key identity elements that MUST appear:
+
+- "specialist agent team" (or close variant) -- this is the consistent phrase across all three sources
+- "Claude Code" -- the platform dependency is stated in every description
+- The agent count (27) -- cited in every canonical source
+- Some indication of structure (orchestration, hierarchy, or governance)
+
+The README opening line is the strongest candidate for the description because it was explicitly authored for external-facing context and captures the three pillars (orchestration, specialists, governance) concisely. The CLAUDE.md version names individual agents, which is too detailed for a one-line About. The architecture.md version is too generic.
+
+**Recommendation**: Use the README opening line as the basis, possibly shortened. Do NOT introduce new framing, new terminology, or a tagline that does not appear in existing documents. The About section should echo, not reinterpret.
+
+#### 2. Website Field
+
+The project has no dedicated website. The only external link in the README is to Claude Code docs and the Helix Manifesto. The repo itself is the canonical location.
+
+**Recommendation**: Leave the website field empty, or point it to the README anchor for install instructions if GitHub allows fragment URLs. Do not fabricate a website or point to an unrelated resource. An empty website field is better than a misleading one.
+
+#### 3. Topics: Accuracy Audit
+
+GitHub topics serve discoverability. They must reflect what the project IS today, not what it aspires to be. Based on my review of the codebase:
+
+**Accurate topics (the project demonstrably IS these things):**
+
+| Topic | Evidence |
+|-------|----------|
+| `claude-code` | Platform dependency stated in README line 6, CLAUDE.md, the-plan.md line 4 |
+| `ai-agents` | The entire project is a set of AI agents |
+| `agent-teams` | README line 6: "Built on Agent Teams"; the-plan.md line 6 |
+| `multi-agent-orchestration` | Nefario's core function; nine-phase orchestration documented extensively |
+| `prompt-engineering` | Every AGENT.md is a crafted system prompt; RESEARCH.md files back each one |
+| `anthropic` | Claude Code is Anthropic's product; the agents use Claude models |
+
+**Borderline topics (require justification):**
+
+| Topic | Verdict | Reasoning |
+|-------|---------|-----------|
+| `llm` | ACCEPTABLE | The agents are LLM-powered, though this is indirect (via Claude Code) |
+| `developer-tools` | ACCEPTABLE | The project functions as developer tooling (install once, use in every session) |
+| `code-quality` | RISKY | Only some agents focus on code quality; the project is broader |
+| `devops` | RISKY | Only iac-minion and edge-minion touch this; not the project's identity |
+| `automation` | RISKY | The project coordinates human-in-the-loop workflows, not autonomous automation |
+
+**Topics to AVOID (would be inaccurate or aspirational):**
+
+| Topic | Why Not |
+|-------|---------|
+| `framework` | The project is not a framework -- it is a set of agent definitions |
+| `ai-framework` | Same -- no framework, no SDK, no library |
+| `autonomous-agents` | Agents require human approval gates; they are not autonomous |
+| `chatbot` | These are not chatbots |
+| `copilot` | This is not a copilot pattern |
+| `mcp` | Only mcp-minion deals with MCP; it is not a project-level concern |
+| `langchain` / `autogen` / other frameworks | Not used |
+
+**Recommendation**: Use 5-7 topics. Prioritize specificity over reach. `claude-code` and `agent-teams` are the most distinctive and accurate. Generic topics like `ai` or `machine-learning` add noise without aiding discoverability for the actual target audience.
+
+#### 4. Tone and Voice Consistency
+
+The project's voice balances:
+- **Technical precision**: Exact counts (27 agents, 7 groups, 23 minions), specific phase names, strict boundary definitions
+- **Playful naming**: Despicable Me characters (Gru, Nefario, Lucy, Margo, minions) woven naturally into technical descriptions
+- **No-nonsense engineering philosophy**: Helix Manifesto, YAGNI, KISS, "more code less blah blah"
+
+The About section should maintain this balance. Specifically:
+
+- DO use "despicable-agents" (lowercase, hyphenated) as the project name -- this is the consistent convention across all docs
+- DO NOT explain the Despicable Me reference -- the existing docs never do, they just use the names naturally
+- DO NOT use marketing language or superlatives -- the README avoids "powerful", "revolutionary", "cutting-edge" and the About should too
+- DO NOT use emoji in the description text -- consistent with CLAUDE.md conventions (the README uses a badge with an emoji, but the prose does not)
+
+#### 5. Contradiction Check Against Design Principles
+
+The four design principles from the-plan.md (generic, publishable, composable, persistent learners) create specific constraints for the About section:
+
+- **Generic**: The description must NOT position this as tied to any specific project or company. The README correctly says "available in every session" and "operates on any project."
+- **Publishable**: The About section is itself a public artifact. No issue here as long as it contains no PII.
+- **Composable**: If mentioned, composability should reference agent combination, not plugin architecture (there is no plugin system).
+- **Persistent learners**: This is an implementation detail (`memory: user` in frontmatter). It should NOT appear in the About section -- it is too granular for a one-line description.
+
+No contradictions detected between the proposed scope (description + website + topics) and the project's stated principles.
+
+### Proposed Tasks
+
+This is an advisory-only contribution. The deliverable is a set of constraints and recommendations, not implementation tasks. The agent responsible for the final About section proposal should:
+
+1. **Draft the description** using the README opening line as the canonical source, shortened to fit GitHub's character limit. Do not invent new framing.
+2. **Select 5-7 topics** from the "Accurate" list above, with at most one from the "Borderline/ACCEPTABLE" list.
+3. **Leave the website field empty** unless a compelling, existing URL is identified.
+4. **Verify the final text** contains no terminology absent from CLAUDE.md, README.md, or the-plan.md.
+
+### Risks and Concerns
+
+1. **Agent count staleness**: The description will hardcode "27 agents" and "2 skills". These numbers will become stale as agents are added or removed. Consider whether the description should use exact counts or a softer formulation ("27+" or omitting counts entirely). The README uses exact counts, so using them in the About is consistent -- but creates a maintenance burden. The agent count has been stable across all canonical docs, so this is low-risk today but worth noting.
+
+2. **Topic drift over time**: GitHub topics are easy to set and forget. If the project adds or removes agent groups, topics should be revisited. No automated mechanism exists to flag this.
+
+3. **Tone mismatch risk**: The About section is the first thing visitors see. If it adopts a different tone than the README (more marketing-heavy, more casual, more formal), it creates a jarring first impression. The safest approach is direct reuse of existing README language.
+
+### Additional Agents Needed
+
+None. This is a straightforward alignment and consistency review. The contributing agent (likely product-marketing-minion or ux-strategy-minion) has the domain expertise to draft the actual content. My role is to constrain the output to match established identity.

--- a/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase2-product-marketing-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase2-product-marketing-minion-prompt.md
@@ -1,0 +1,54 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet -- you are providing your domain expertise
+to help build a comprehensive recommendation.
+
+## Project Task
+
+Propose description, website, and topics for the GitHub "About" section of the despicable-agents repo. The About section is currently completely empty.
+
+## Your Planning Question
+
+Given that despicable-agents is an open-source (Apache 2.0) specialist agent framework for Claude Code with 27 agents, phased orchestration, and built-in governance -- what description (max ~350 chars) best communicates the value proposition to developers discovering the repo on GitHub? Consider: what makes this different from other AI agent frameworks? What keywords should appear in the description for scanning readability? Should the tone lean technical/functional or slightly playful (given the Despicable Me naming)?
+
+## Context
+
+- Repo: https://github.com/benpeter/despicable-agents
+- License: Apache 2.0, Primary language: Shell
+- README tagline: "Structured orchestration, domain specialists, and governance gates for Claude Code. Built on Agent Teams. 27 agents, 2 skills, available in every session after a one-time install."
+- Key differentiators from README "What You Get":
+  1. Phased orchestration -- nine structured phases from meta-planning through parallel execution to post-execution verification
+  2. Research-backed domain experts -- 27 agents built from domain research, each with strict boundaries
+  3. Built-in governance and quality gates -- five mandatory reviewers examine every plan before code runs
+  4. Goodies -- execution reports, /despicable-prompter skill, install once available everywhere
+- Agent roster: gru (AI visionary), nefario (orchestrator), lucy & margo (governance), 23 domain-specialist minions
+- Design principles from the-plan.md: generic domain specialists, publishable, composable, persistent learners
+- Engineering philosophy: follows Helix Manifesto -- YAGNI, KISS, lean and mean
+
+## Advisory Context
+
+This is an advisory-only orchestration. Your contribution will feed into a team recommendation, not an execution plan. Focus on analysis, trade-offs, and recommendations rather than implementation tasks.
+
+## Instructions
+
+1. Read the README.md and docs/architecture.md to understand current project positioning
+2. Apply your domain expertise to the planning question
+3. Propose 2-3 candidate descriptions with trade-off analysis
+4. Recommend a website URL strategy (link to README? docs? leave blank?)
+5. Identify risks and concerns from your perspective
+6. Return your contribution in this format:
+
+## Domain Plan Contribution: product-marketing-minion
+
+### Recommendations
+<your expert recommendations>
+
+### Proposed Tasks
+<specific deliverables for the advisory>
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+None (or explain why)
+
+7. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-q2AEa6/gh-about-section-proposal/phase2-product-marketing-minion.md

--- a/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase2-product-marketing-minion.md
+++ b/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase2-product-marketing-minion.md
@@ -1,0 +1,161 @@
+# Domain Plan Contribution: product-marketing-minion
+
+## Recommendations
+
+### Description Analysis
+
+The GitHub About description is the most compressed positioning artifact a repo has. It appears in search results, topic listings, user profiles (pinned repos), and the repo sidebar. Developers scanning GitHub make stay-or-leave decisions based on this line alone. Every word must earn its place.
+
+**Constraints:**
+- GitHub enforces a 350-character hard limit on repository descriptions.
+- The description renders as a single paragraph -- no line breaks, no formatting.
+- It appears alongside the repo name, so "despicable-agents" is already visible context. The description should not repeat the repo name.
+- On search result pages, descriptions are often truncated around 150-170 characters, so front-load the most important information.
+
+**Competitive landscape for positioning context:**
+- `ruvnet/claude-flow`: "The leading agent orchestration platform for Claude. Deploy intelligent multi-agent swarms, coordinate autonomous workflows..." -- overclaims ("Ranked #1"), buzzword-heavy ("enterprise-grade," "swarm intelligence"), developer-repellent marketing language.
+- `VoltAgent/awesome-claude-code-subagents`: "A collection of 100+ specialized Claude Code subagents covering a wide range of development use cases" -- factual but generic. Reads as a list, not a system.
+- `wshobson/agents`: "Intelligent automation and multi-agent orchestration for Claude Code" -- concise but undifferentiated. Could describe any multi-agent setup.
+
+**What makes despicable-agents genuinely different (unique attributes mapped to value):**
+1. **Governance gates before execution** -- No other Claude Code agent framework mandates five reviewers before code runs. This is the strongest differentiator because it addresses the core fear developers have with AI agents: "it will break things."
+2. **Phased orchestration with approval gates** -- Nine structured phases vs. "just send it." Developers stay in control.
+3. **Research-backed specialist boundaries** -- Not just a collection of agents. Each has strict "does NOT do" sections preventing overlap and hallucinated delegation.
+4. **Install once, use everywhere** -- Symlink-based deployment means agents are available in every Claude Code session. No per-project configuration.
+
+**Target persona for the description:**
+A developer already using Claude Code who wants to scale beyond single-agent interactions. They have encountered the limitations of generalist prompting for complex tasks (security review, multi-domain feature work) and are looking for structure. They are not looking for a new platform -- they want to enhance what they already use. They value control over autonomy.
+
+### Candidate Descriptions
+
+**Candidate A -- Lead with structure and governance (recommended)**
+
+> 27 specialist agents for Claude Code with phased orchestration and governance gates. Domain experts for security, testing, API design, infrastructure, and more -- each with strict boundaries. Five mandatory reviewers check every plan before code runs. Install once, use in any project.
+
+Character count: 299
+
+Trade-offs:
+- (+) Front-loads the number "27" which signals scale and completeness
+- (+) "Governance gates" is the key differentiator, appears early
+- (+) "Before code runs" directly addresses the AI-agent trust problem
+- (+) "Install once, use in any project" is a concrete convenience benefit
+- (+) Lists real domain examples so developers can pattern-match to their needs
+- (-) Does not mention the Despicable Me theming -- purely functional
+- (-) Dense. A lot to parse in one line.
+
+**Candidate B -- Lead with the job-to-be-done**
+
+> Structured orchestration for Claude Code: 27 research-backed agents decompose complex tasks, route to domain specialists, and run governance gates before any code executes. Security, testing, API design, docs, and 19 more domains. One install, every project.
+
+Character count: 286
+
+Trade-offs:
+- (+) Opens with "Structured orchestration for Claude Code" -- scannable, immediately categorizes the repo
+- (+) "Research-backed" hints at depth without overclaiming
+- (+) "Before any code executes" is the trust hook
+- (+) "One install, every project" is punchy
+- (-) "Decompose complex tasks, route to domain specialists" is process description rather than outcome
+- (-) Still no personality from the theme
+
+**Candidate C -- Functional with a light thematic nod**
+
+> 27 specialist agents for Claude Code. Nefario orchestrates across domains, governance gates catch problems before code runs, and each minion has strict boundaries backed by domain research. Security, testing, APIs, infrastructure, docs, and more. Install once, use everywhere.
+
+Character count: 289
+
+Trade-offs:
+- (+) "Nefario" and "minion" are organic references to the theme without being forced -- they are literally the agent names
+- (+) "Governance gates catch problems before code runs" is benefit-oriented, not feature-oriented
+- (+) Using the actual role names (Nefario, minion) helps developers understand the agent hierarchy from the description alone
+- (-) Readers unfamiliar with the theming may find "Nefario" and "minion" confusing without context
+- (-) Slightly less keyword-dense for search
+
+### Recommendation: Candidate A
+
+Candidate A is the strongest for GitHub discovery. Here is why:
+
+1. **Front-loading matters.** On truncated search results, "27 specialist agents for Claude Code with phased orchestration and governance gates" is what survives. That is the complete positioning in one clause.
+
+2. **Governance is the real differentiator.** The competitive landscape is full of "multi-agent orchestration" claims. Nobody else is leading with mandatory review before execution. This addresses the most important developer concern with AI agent systems: trust and control.
+
+3. **Skipping the theme is correct for the description.** The Despicable Me naming is a discovery hook that works in the README, repo name, and docs -- contexts where there is room to explain it. In a 300-character description competing for attention in search results, clarity beats cleverness. The repo name "despicable-agents" already signals the theme. The description should explain what it does, not reinforce the brand.
+
+4. **Candidate C is a viable alternative** if the team values surfacing the agent hierarchy vocabulary (Nefario, minion) early. It has a legitimate argument: developers who install the tool will interact with these names immediately, so introducing them in the description reduces onboarding friction. If the team prefers C, the risk of initial confusion is low given that "minion" is widely understood as "specialist worker."
+
+### Website URL
+
+**Recommendation: Leave blank or point to the README.**
+
+Options analyzed:
+
+| Option | Verdict | Rationale |
+|--------|---------|-----------|
+| Blank | Acceptable | The README is already the landing page. A website link adds nothing if it just links back to the same page the user is already on. |
+| `https://github.com/benpeter/despicable-agents#readme` | Marginal | Anchors to the README from search results, but GitHub already surfaces the README on the repo page. Adds a link that goes nowhere new. |
+| `https://github.com/benpeter/despicable-agents/blob/main/docs/using-nefario.md` | Considered | Would surface the "Using Nefario" guide for faster time-to-value. But the URL is ugly and non-obvious in sidebar display. |
+| Dedicated docs site (future) | Best long-term | If the project grows, a `despicable-agents.dev` or GitHub Pages site would be the ideal website link. But building this is not warranted yet (YAGNI). |
+
+**Verdict: Leave blank for now.** When a dedicated documentation site exists, add it. Until then, the README is the landing page and GitHub already displays it.
+
+### Topics (Tags)
+
+GitHub topics drive discoverability. They appear in search, topic pages, and "Explore" recommendations. Choose topics that match what the target developer would search for.
+
+**Recommended topics (ordered by priority):**
+
+1. `claude-code` -- Primary platform. Developers searching for Claude Code extensions will find this.
+2. `ai-agents` -- Broad category for multi-agent systems. High traffic.
+3. `agent-orchestration` -- Specific to the orchestration value prop.
+4. `claude` -- Broader Anthropic ecosystem discovery.
+5. `multi-agent` -- Alternative search term for the same concept.
+6. `developer-tools` -- General category for tooling repos.
+7. `code-review` -- One of the concrete capabilities, and a high-intent search term.
+8. `claude-code-agents` -- Emerging compound topic specific to this ecosystem.
+
+**Topics to avoid:**
+- `awesome` or `awesome-list` -- This is not a curated list, it is a framework.
+- `llm` or `large-language-models` -- Too broad, will attract users who are not Claude Code users.
+- `ai` -- Too generic, low signal-to-noise.
+- `devops`, `security`, `testing` -- These are agent domains, not the repo's purpose.
+
+**Recommended set (8 topics):**
+`claude-code`, `ai-agents`, `agent-orchestration`, `claude`, `multi-agent`, `developer-tools`, `claude-code-agents`, `code-quality`
+
+(GitHub allows up to 20 topics, but fewer high-quality topics are better than many diluted ones. These 8 cover the primary discovery paths.)
+
+### Tone Guidance
+
+The question of technical vs. playful tone deserves explicit analysis:
+
+**The repo name is already doing the playful work.** "despicable-agents" is an immediate signal that this project has personality. Agent names like "gru," "nefario," "lucy," "margo," and "minion" reinforce it everywhere in the documentation. Adding playfulness to the description (e.g., "Deploy your minion army...") would be redundant and risks undermining the credibility of the governance and quality claims -- the very things that differentiate this project.
+
+**The description should be the credibility anchor.** The playful naming catches attention. The functional description converts that attention into understanding. This is the classic "interesting name, serious tool" pattern used effectively by projects like Terraform (planet-shaping name, infrastructure automation tool), Kubernetes (Greek for "helmsman," container orchestration platform), and Grafana (portmanteau name, serious monitoring tool).
+
+**Rule: Fun names, serious descriptions.**
+
+## Proposed Tasks
+
+This is an advisory contribution. The deliverables are the analysis and recommendations above, specifically:
+
+1. Three candidate descriptions with trade-off analysis and a clear recommendation (Candidate A)
+2. Website URL strategy with options matrix (recommend: leave blank)
+3. Topic tag set with rationale (8 topics recommended)
+4. Tone guidance with reasoning ("fun names, serious descriptions")
+
+No implementation tasks are needed from this domain -- the About section is configured via GitHub UI or API, not via code artifacts.
+
+## Risks and Concerns
+
+1. **Character count uncertainty.** GitHub's description limit appears to be 350 characters based on available evidence, but this has changed over time. All three candidates are under 300 characters. If the limit is lower than expected, Candidate B (286 chars) or a trimmed version of A would still work. The first clause of each candidate ("27 specialist agents for Claude Code with phased orchestration and governance gates" at 89 characters) functions as a standalone description if severe truncation is needed.
+
+2. **Topic volatility.** The `claude-code` and `claude-code-agents` topics are emerging and may not yet have significant search volume on GitHub. This is actually an advantage for early positioning -- being one of the first well-described repos in a growing topic is better than being the 10,000th repo tagged `ai`. Monitor topic adoption quarterly.
+
+3. **Description staleness.** If the agent count changes (adds or removes agents), the description becomes inaccurate. "27" is specific and credible now, but requires maintenance. Alternative: "25+" is future-proof but less precise. Recommendation: keep the exact number and update it when the roster changes. Precision builds trust.
+
+4. **Governance claim verification.** The description claims "five mandatory reviewers check every plan." A developer who installs the tool and finds this is not enforced (or is skippable) will lose trust immediately. Ensure the README and orchestration behavior match this claim exactly before publishing it as the description.
+
+5. **Competitive description drift.** The competitor descriptions analyzed above will change. The positioning recommendation is durable because it is based on a genuine architectural differentiator (governance gates), not a temporary gap. But revisit if a competitor adopts similar governance patterns.
+
+## Additional Agents Needed
+
+None. The GitHub About section is a pure positioning artifact within product-marketing-minion's domain. The description, website, and topics decisions are messaging and discoverability questions, not technical or design questions.

--- a/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase2-seo-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase2-seo-minion-prompt.md
@@ -1,0 +1,50 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet -- you are providing your domain expertise
+to help build a comprehensive recommendation.
+
+## Project Task
+
+Propose description, website, and topics for the GitHub "About" section of the despicable-agents repo. The About section is currently completely empty.
+
+## Your Planning Question
+
+What GitHub topics maximize discoverability for this repo? Consider: (1) what terms developers search when looking for Claude Code extensions, AI agent frameworks, or multi-agent orchestration tools; (2) which existing GitHub topic ecosystems have active communities (e.g., `claude`, `anthropic`, `ai-agents`, `llm`); (3) the balance between broad topics (high traffic, low signal) and specific topics (low traffic, high relevance); (4) GitHub's topic limit and best practices for topic count. Research what topics competing/related repos use (e.g., claude-code tools, MCP servers, AI agent frameworks).
+
+## Context
+
+- Repo: https://github.com/benpeter/despicable-agents
+- License: Apache 2.0, Primary language: Shell
+- Core technology: Claude Code, Agent Teams, specialist agents
+- Domain terms: multi-agent orchestration, domain specialists, governance gates, phased orchestration
+- Key associations: Anthropic, Claude, Claude Code, MCP (Model Context Protocol)
+- The project is NOT a framework/library -- it's a set of deployable agents and skills
+- Install method: symlinks to ~/.claude/ directory
+
+## Advisory Context
+
+This is an advisory-only orchestration. Your contribution will feed into a team recommendation, not an execution plan. Focus on analysis, trade-offs, and recommendations rather than implementation tasks.
+
+## Instructions
+
+1. Research GitHub topic ecosystems relevant to this project
+2. Analyze what topics similar repos (claude-code extensions, AI agent frameworks) use
+3. Propose a curated topic list with rationale for each topic
+4. Consider topic count best practices (GitHub recommends up to 20, but most effective repos use 5-15)
+5. Identify risks and concerns from your perspective
+6. Return your contribution in this format:
+
+## Domain Plan Contribution: seo-minion
+
+### Recommendations
+<your expert recommendations>
+
+### Proposed Tasks
+<specific deliverables for the advisory>
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+None (or explain why)
+
+7. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-q2AEa6/gh-about-section-proposal/phase2-seo-minion.md

--- a/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase2-seo-minion.md
+++ b/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase2-seo-minion.md
@@ -1,0 +1,128 @@
+## Domain Plan Contribution: seo-minion
+
+### Recommendations
+
+#### 1. GitHub Topic Ecosystem Analysis
+
+I researched the size and activity of every relevant GitHub topic ecosystem. Here is the landscape as of February 2026:
+
+| Topic | Repository Count | Signal Quality | Notes |
+|-------|-----------------|----------------|-------|
+| `llm` | 39,092 | Very broad, low signal | Catch-all; every LLM-adjacent project uses it |
+| `ai-agents` | 9,338 | Broad but relevant | Active community, strong discovery channel |
+| `claude` | 6,927 | Moderate, Claude-specific | Large ecosystem; high relevance for this project |
+| `claude-code` | 6,003 | High relevance | Exact platform match; the core discovery term |
+| `agentic-ai` | 5,469 | Broad, trending | Fast-growing in 2025-2026; trendy but noisy |
+| `anthropic` | 2,782 | Moderate | Vendor-specific; relevant audience |
+| `multi-agent-systems` | 1,895 | Academic leaning | Used by research-oriented repos; somewhat relevant |
+| `multi-agent` | 1,452 | Moderate | Broader than `multi-agent-systems`; overlaps |
+| `claude-skills` | 615 | High relevance | Exact feature match; growing ecosystem |
+| `agent-orchestration` | 184 | Niche, high precision | Small but perfectly targeted audience |
+| `claude-agents` | 38 | Very niche | Emerging topic; low traffic but exact match |
+| `claude-extensions` | 11 | Too small | Negligible discovery value |
+
+#### 2. Competitive Topic Analysis
+
+I examined what topics the most successful comparable repos use.
+
+**wshobson/agents** (28.5k stars -- Claude Code multi-agent orchestration):
+`automation`, `orchestration`, `workflows`, `agents`, `anthropic`, `claude-code`, `subagents`, `claude-skills`
+
+**ruvnet/claude-flow** (14k stars -- agent orchestration platform):
+Topics emphasize `ai-agents`, `multi-agent-systems`, `agent-orchestration`, `claude`
+
+**everything-claude-code** (45.3k stars -- Claude Code config collection):
+`productivity`, `mcp`, `developer-tools`, `ai-agents`, `claude`, `llm`, `anthropic`
+
+**crewAI** (44.1k stars -- multi-agent framework):
+Uses broad AI and orchestration terms
+
+**Common patterns across successful repos:**
+- They all include `claude-code` (platform anchor)
+- They all include at least one of `anthropic` or `claude` (vendor signal)
+- They mix 2-3 broad topics (`ai-agents`, `llm`) with 2-3 specific ones (`claude-skills`, `agent-orchestration`)
+- None exceed 12 topics; most use 6-10
+
+#### 3. Proposed Topic List (Tiered)
+
+I recommend **10 topics**, organized into three tiers by strategic function.
+
+**Tier 1: Platform Identity (must-have, exact match for target audience)**
+
+| # | Topic | Rationale |
+|---|-------|-----------|
+| 1 | `claude-code` | The platform this project runs on. 6,003 repos. Primary discovery channel for anyone searching for Claude Code extensions. Every comparable project uses this. |
+| 2 | `claude-agents` | Exact descriptor for what this project is. Only 38 repos -- low traffic but the term is emerging and this project should establish presence early. As the ecosystem grows, early entrants rank higher. |
+| 3 | `claude-skills` | The project includes deployable skills (nefario, despicable-prompter). 615 repos. Active, growing community. Matches how Anthropic's own documentation describes the extension mechanism. |
+
+**Tier 2: Domain Descriptors (high-relevance terms that describe what the project does)**
+
+| # | Topic | Rationale |
+|---|-------|-----------|
+| 4 | `agent-orchestration` | Nefario's core function. 184 repos -- niche but precisely the audience who would want this. Developers searching this term are looking for exactly what despicable-agents provides. |
+| 5 | `multi-agent` | Broad descriptor for the project's architecture. 1,452 repos. Bridges between the Claude-specific and general AI agent communities. More discoverable than `multi-agent-systems` (which skews academic) or `multi-agent-orchestration` (which has very few repos). |
+| 6 | `ai-agents` | The broadest relevant term. 9,338 repos. Provides exposure to the general AI agent community. Every top competitor uses this topic. Omitting it sacrifices significant discovery surface. |
+| 7 | `prompt-engineering` | Each agent is a carefully crafted system prompt backed by domain research. This topic brings in developers interested in prompt design patterns, which is a real use case for studying this repo. |
+
+**Tier 3: Ecosystem Anchors (vendor/platform association for browsing discovery)**
+
+| # | Topic | Rationale |
+|---|-------|-----------|
+| 8 | `anthropic` | Vendor association. 2,782 repos. Developers browsing "what tools exist in the Anthropic ecosystem" will find this. Every comparable project includes this. |
+| 9 | `agent-teams` | Matches the Claude Code feature this project builds on ("Built on Agent Teams" -- README line 6). This may be a very small or nonexistent topic today, but it is the official Anthropic terminology. Establishing presence on this term is forward-looking. |
+| 10 | `developer-tools` | Functional category. Signals that this is a practical tool, not a research project or demo. Helps developers scanning topic lists understand what kind of repo this is. |
+
+#### 4. Topics Deliberately Excluded (with reasoning)
+
+| Topic | Why Excluded |
+|-------|-------------|
+| `llm` | Too broad (39k repos). Adds noise, not signal. The audience finding repos via `llm` is not specifically looking for Claude Code agent teams. The Claude-specific topics serve discovery better. |
+| `claude` | Overlaps heavily with `claude-code` and `anthropic`. At 6,927 repos it is large but undifferentiated. Adding it alongside `claude-code`, `claude-agents`, and `claude-skills` creates redundancy. If topic count must be reduced below 10, adding `claude` back in place of a Tier 2 or 3 topic is reasonable. |
+| `agentic-ai` | Trending buzzword (5,469 repos). The project does not describe itself using this term in any canonical document. Per Lucy's consistency guidance, topics should reflect established terminology. |
+| `automation` | Risky per Lucy's analysis -- the project coordinates human-in-the-loop workflows, not autonomous automation. Using this topic could attract the wrong audience and set incorrect expectations. |
+| `framework` / `ai-framework` | The project is NOT a framework. It is a set of deployable agents and skills. Tagging it as a framework is inaccurate and would create confusion when developers expect an SDK or library. |
+| `mcp` | Only one agent (mcp-minion) deals with MCP. This is not a project-level concern. |
+| `multi-agent-systems` | Skews academic (1,895 repos dominated by research papers and simulation frameworks). `multi-agent` captures the same intent with a broader audience. |
+| `claude-extensions` | Only 11 repos. Negligible discovery value. Not worth spending a topic slot on. |
+
+#### 5. Topic Count Rationale
+
+GitHub allows a maximum of 20 topics per repository. However, research and competitive analysis show:
+
+- **Most effective repos use 6-12 topics.** Beyond 12, the marginal discovery value per additional topic drops sharply while visual clutter increases (topics render as a tag cloud on the repo page).
+- **10 topics** is the sweet spot for this project: enough to cover all three tiers (platform, domain, ecosystem) without dilution.
+- **Poorly annotated projects with only 1-3 topics are measurably less discoverable** than well-annotated ones. But overloading with 15-20 generic topics signals spam behavior and reduces credibility.
+
+The 10-topic recommendation leaves room to add 1-2 more if the project evolves (e.g., if a `governance` or `code-review` topic becomes relevant as those features mature).
+
+#### 6. Discovery Strategy Beyond Topics
+
+Topics are the primary mechanism, but two adjacent factors affect GitHub discoverability:
+
+**Description as search text**: GitHub's search indexes the About description. Keywords in the description that do NOT appear in topics still contribute to search ranking. The description should therefore contain complementary terms (e.g., "governance gates" or "domain specialists") that would be too niche for topics but are meaningful search queries.
+
+**README first paragraph**: GitHub search also indexes the README. The current README opening is well-optimized -- it contains "structured orchestration", "domain specialists", "governance gates", "Claude Code", "Agent Teams", and "27 agents" within the first two lines. No changes needed there.
+
+### Proposed Tasks
+
+1. **Set 10 GitHub topics** in the order listed above (Tier 1 first, then Tier 2, then Tier 3). The order does not affect discoverability but communicates priority to anyone reviewing the repo settings.
+
+2. **Ensure the About description contains keywords complementary to the topics** -- specifically terms like "governance", "domain specialists", "orchestration", and "specialist agents" that serve as secondary search signals without needing their own topic slots.
+
+3. **Revisit topics when agent count or scope changes** -- if agents are added or removed, or if the project adds significant new capabilities (e.g., an MCP server, a web UI), topics should be updated to match.
+
+### Risks and Concerns
+
+1. **Emerging topic instability**: `claude-agents` (38 repos) and `agent-teams` (possibly new) are very small topics. There is a risk they never gain traction and provide zero discovery value. Mitigation: the cost of including them is zero (they occupy topic slots but do not harm discovery). If they grow, this project benefits from being an early presence. If they stagnate, they can be swapped out later.
+
+2. **Topic ecosystem fragmentation**: The Claude Code ecosystem has multiple overlapping topics (`claude`, `claude-code`, `claude-agents`, `claude-skills`, `claude-ai`, `anthropic-claude`, `anthropic`). There is no canonical topic hierarchy. This fragmentation means discovery is scattered across many small pools rather than concentrated in one large one. The proposed list addresses this by covering the three largest pools (`claude-code`, `claude-skills`, `anthropic`) while also claiming presence in the most precise niche (`claude-agents`).
+
+3. **"agent-teams" topic may not exist yet**: If GitHub does not have an established `agent-teams` topic, creating it from a single repo provides no discovery value until others adopt it. However, if Anthropic promotes this term in their documentation (which they currently do), adoption should follow. If it does not exist after 3-6 months, replace with `claude` as a fallback.
+
+4. **Broad vs. niche balance risk**: The list leans toward niche precision over broad reach. This is intentional -- the project serves a specific audience (Claude Code users who want agent teams). Broad topics like `ai` or `llm` would bring traffic but not the right traffic. However, if the repo owner wants maximum star count over maximum qualified traffic, adding `llm` and `claude` back would increase raw exposure.
+
+5. **Topic maintenance is manual**: Unlike structured data on a website, GitHub topics have no automated validation or staleness detection. If the project scope changes (e.g., drops orchestration or adds framework-like features), outdated topics will persist until manually updated.
+
+### Additional Agents Needed
+
+None. The topic strategy is complete within the SEO domain. Lucy's contribution already provides the accuracy constraints I need (topics must reflect what the project IS, not what it aspires to be). The product-marketing and UX-strategy contributions will inform the description text, which complements topics for search but is not a topic selection concern.

--- a/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase2-ux-strategy-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase2-ux-strategy-minion-prompt.md
@@ -1,0 +1,50 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet -- you are providing your domain expertise
+to help build a comprehensive recommendation.
+
+## Project Task
+
+Propose description, website, and topics for the GitHub "About" section of the despicable-agents repo. The About section is currently completely empty.
+
+## Your Planning Question
+
+From a user journey perspective, a developer lands on this GitHub repo page and sees the About section first. What information hierarchy best serves the "should I care about this?" decision in 3 seconds? Should the description lead with what it IS (specialist agent team for Claude Code), what it DOES (orchestrated multi-agent execution with governance), or what PROBLEM it solves (complex tasks get decomposed across domain experts)? Does the Despicable Me theming help or hurt first-impression comprehension for developers who have never heard of this project?
+
+## Context
+
+- Repo: https://github.com/benpeter/despicable-agents
+- The GitHub About section appears in the right sidebar on the repo page
+- Description appears immediately below the repo name in search results and the repo page
+- Current README first line: "Structured orchestration, domain specialists, and governance gates for Claude Code. Built on Agent Teams. 27 agents, 2 skills, available in every session after a one-time install."
+- Examples from README show usage patterns: @security-minion, @debugger-minion, /nefario, /despicable-prompter
+- Install: ./install.sh symlinks everything to ~/.claude/
+- Target audience: developers already using Claude Code who want structured multi-agent workflows
+
+## Advisory Context
+
+This is an advisory-only orchestration. Your contribution will feed into a team recommendation, not an execution plan. Focus on analysis, trade-offs, and recommendations rather than implementation tasks.
+
+## Instructions
+
+1. Read the README.md to understand the current first-impression flow
+2. Evaluate cognitive load of different description approaches
+3. Assess the Despicable Me theming's impact on comprehension
+4. Recommend an information hierarchy for the description
+5. Identify risks and concerns from your perspective
+6. Return your contribution in this format:
+
+## Domain Plan Contribution: ux-strategy-minion
+
+### Recommendations
+<your expert recommendations>
+
+### Proposed Tasks
+<specific deliverables for the advisory>
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+None (or explain why)
+
+7. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-q2AEa6/gh-about-section-proposal/phase2-ux-strategy-minion.md

--- a/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase2-ux-strategy-minion.md
+++ b/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase2-ux-strategy-minion.md
@@ -1,0 +1,125 @@
+# Domain Plan Contribution: ux-strategy-minion
+
+## Recommendations
+
+### 1. Lead with WHAT IT IS, not what it does or what problem it solves
+
+The "should I care?" decision on GitHub is a two-stage satisficing process:
+
+1. **Pattern matching (under 2 seconds):** "Is this thing in my category?" The developer scans for recognition cues -- does this relate to a tool I already use? If they can't place the project in a mental category within 2 seconds, they bounce.
+2. **Value assessment (next 1-3 seconds):** "Does it offer something I don't already have?" Only after categorization do they evaluate differentiation.
+
+Leading with the problem ("complex tasks get decomposed across domain experts") forces the reader to work backwards to figure out what this even is. That's germane load spent on comprehension rather than evaluation. Leading with what it does ("orchestrated multi-agent execution with governance") is better but still requires the reader to infer the category.
+
+**Lead with what it IS: a specialist agent team for Claude Code.** This immediately places the project in the reader's mental model. "Claude Code" is the anchor. "Agent team" is the category. Everything else is secondary.
+
+The current README first line gets this right: "Structured orchestration, domain specialists, and governance gates for Claude Code." That leads with the category (Claude Code tooling), then layers in the differentiators. The About description should follow the same pattern but compressed to the ~100-character sweet spot for scanability.
+
+### 2. The Despicable Me theming: net neutral to slightly positive, but needs management
+
+**Analysis of the theming's cognitive impact:**
+
+- **Risk: confusion at first glance.** A developer searching for "claude code agents" who sees "despicable-agents" might briefly wonder if this is a joke project, a parody, or unserious. The name creates a 0.5-1 second comprehension tax.
+- **Mitigant: the description resolves it immediately.** If the description clearly states what this is (agent team for Claude Code), the name becomes a memorable quirk rather than a barrier. The theming (Gru, Nefario, minions) actually helps recall -- "oh, the one with the Minions theme" is stickier than "claude-agent-framework-27."
+- **Comparable pattern:** Developer tools with playful names succeed constantly (Homebrew, Bun, Deno, Fastify). The name is not the comprehension barrier -- the description is.
+- **Key constraint:** The description MUST NOT lean into the theming. No "Deploy your minion army" or "Let Gru orchestrate your code." The description should be purely functional. Let the repo name carry the personality; let the description carry the information.
+
+**Verdict:** The theming helps memorability and differentiation in a crowded space (there are now many "claude code agent" repos). It does not hurt comprehension IF the description is clear and functional. The About description is the place to be serious, not playful.
+
+### 3. Information hierarchy for the description
+
+GitHub About description constraint: ~350 characters max (varies by context), but only ~100-120 characters display without truncation in search results and the repo sidebar. The first ~100 characters are the only ones that matter for the satisficing decision.
+
+**Recommended hierarchy (front-loaded for truncation):**
+
+```
+[What it IS] [Key differentiator] [Scope signal]
+```
+
+Specifically:
+- **What it IS:** "Specialist agent team for Claude Code" -- places the project instantly
+- **Key differentiator:** "with orchestration and governance" -- separates it from collections/lists of agents
+- **Scope signal:** "27 agents, 2 skills" -- signals maturity and completeness
+
+This maps to the JTBD: "When I'm using Claude Code and want structured multi-agent workflows, I want a pre-built team of domain specialists with orchestration, so I can decompose complex tasks without building the agent infrastructure myself."
+
+### 4. Recommended description options (ranked)
+
+**Option A (recommended, 106 chars):**
+```
+Specialist agent team for Claude Code -- 27 domain experts with orchestration and governance gates.
+```
+Why: Leads with category (agent team + Claude Code). Differentiates (domain experts, orchestration, governance). Scope signal (27). All within the non-truncated display zone.
+
+**Option B (shorter, 89 chars):**
+```
+27 specialist agents for Claude Code with orchestrated multi-agent execution and governance.
+```
+Why: Number-first grabs attention. Clear category. Slightly less clear on the "team" concept.
+
+**Option C (problem-forward, 109 chars):**
+```
+Orchestrated agent team for Claude Code -- domain specialists decompose complex tasks with governance gates.
+```
+Why: Leads with the differentiator (orchestration). Trades immediate categorization for immediate value proposition.
+
+**I recommend Option A.** It front-loads categorization ("specialist agent team for Claude Code"), then immediately differentiates. The reader knows what this is in the first 40 characters, then learns why it's different in the next 60.
+
+### 5. Topics (tags) recommendations
+
+Topics serve two functions: discoverability (search/browse) and cognitive framing (quick category signals). Apply these principles:
+
+- **Use established terms** that developers already search for
+- **Don't duplicate** what's in the description
+- **Mix category tags and technology tags** -- category for "what is this", technology for "does it work with my stack"
+
+**Recommended topics (8-10, ordered by priority):**
+
+1. `claude-code` -- primary ecosystem anchor
+2. `ai-agents` -- category
+3. `multi-agent` -- architecture pattern
+4. `agent-orchestration` -- differentiating capability
+5. `claude` -- broader ecosystem discovery
+6. `developer-tools` -- general category
+7. `code-review` -- specific capability users search for
+8. `agent-teams` -- Claude Code feature name
+9. `ai-coding` -- discovery term
+10. `anthropic` -- ecosystem
+
+Avoid: `despicable-me`, `minions` (confuses category), `awesome` (overused, diluted signal), overly specific agent names.
+
+### 6. Website field
+
+The About section has a website URL field. Two options:
+
+- **Leave blank:** The README serves as the landing page. Adding a URL that points back to the repo itself is circular and adds noise.
+- **Point to the docs:** If `docs/using-nefario.md` or similar is the most useful "next step" for an interested developer, link to it. But GitHub already renders the README below.
+
+**Recommendation:** Leave blank unless there's a standalone docs site or a particularly compelling getting-started page. The README is the website for this project.
+
+## Proposed Tasks
+
+Since this is advisory-only, the deliverables are recommendations:
+
+1. **Description text** -- final copy for the GitHub About description field (see Option A above)
+2. **Topics list** -- ordered list of 8-10 topics for the About section
+3. **Website field recommendation** -- blank or specific URL with rationale
+4. **Theming guidance** -- brief note on when to lean into vs. away from the Despicable Me theming in different contexts (About = serious, README = personality is fine)
+
+## Risks and Concerns
+
+### Risk 1: Description truncation across contexts
+GitHub displays the description differently in search results, repo page sidebar, organization page, and social embeds (Open Graph). The first ~100 characters must carry the full message independently. Anything after that is bonus context that may or may not display. All recommended options above are within this constraint.
+
+### Risk 2: Competitive positioning in a crowded space
+There are now multiple "claude code agent" repos (wshobson/agents with 112 agents, VoltAgent with 100+, ruvnet/claude-flow with 14k stars). The description needs to differentiate, not just categorize. The key differentiators for despicable-agents are: (a) governance gates, (b) structured orchestration phases, (c) research-backed agent boundaries. The description should signal at least one of these. "Governance gates" is the most unique -- the competition talks about "orchestration" and "multi-agent" but not governance.
+
+### Risk 3: The theming polarizes
+Some developers will find the Despicable Me theming charming and memorable. Others will read it as unserious or confusing (especially non-English speakers less familiar with the franchise). The About description is not the place to mitigate this -- the name is the name. But the description should be unambiguously professional and informative to counterbalance any skepticism the name creates.
+
+### Risk 4: Number inflation arms race
+"27 agents" is a meaningful scope signal today. But competitors advertise "100+" and "112" agents. If the number invites unfavorable comparison, consider whether to include it. Counter-argument: 27 purpose-built agents with governance is a different proposition than 100+ agents without it. The number plus "domain experts" signals quality over quantity.
+
+## Additional Agents Needed
+
+None. This is a contained UX strategy analysis. The final copy might benefit from product-marketing-minion reviewing the description for positioning and messaging effectiveness, but that is already part of the orchestration if needed.

--- a/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase3-synthesis-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase3-synthesis-prompt.md
@@ -1,0 +1,40 @@
+MODE: SYNTHESIS
+ADVISORY: true
+
+You are synthesizing specialist planning contributions into a
+team recommendation. This is an advisory-only orchestration --
+no code will be written, no branches created, no PRs opened.
+
+Do NOT produce task prompts, agent assignments, execution order,
+approval gates, or delegation plan structure. Produce an advisory
+report using the advisory output format defined in your AGENT.md.
+
+## Original Task
+
+Propose description, website, and topics for the GitHub "About" section of the despicable-agents repo. The About section is currently completely empty.
+
+## Specialist Contributions
+
+Read the following scratch files for full specialist contributions:
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-q2AEa6/gh-about-section-proposal/phase2-product-marketing-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-q2AEa6/gh-about-section-proposal/phase2-seo-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-q2AEa6/gh-about-section-proposal/phase2-ux-strategy-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-q2AEa6/gh-about-section-proposal/phase2-lucy.md
+
+## Key consensus across specialists:
+
+- product-marketing-minion: Lead with governance as primary differentiator; fun names, serious descriptions. 299-char description emphasizing 27 agents, phased orchestration, governance gates, mandatory reviewers. Recommends 8 topics. Website: leave blank.
+- seo-minion: 10 topics in 3 tiers favoring niche precision over broad reach; target Claude Code users, not general AI community. Excluded `llm`, `claude`, `framework` as too broad/inaccurate. Website: leave blank.
+- ux-strategy-minion: Lead with WHAT IT IS for fastest pattern matching; keep description short (~106 chars) so first 100 chars are self-sufficient. Theming is net neutral -- let name carry personality, description carry information. Website: leave blank.
+- lucy: Base description on README opening line; verified strong internal consistency across all canonical docs. 5-7 topics from verified-accurate set only; avoid aspirational terms. Website: leave blank.
+
+## Instructions
+
+1. Review all specialist contributions
+2. Resolve any conflicts between recommendations
+3. Identify consensus and dissent -- preserve minority positions
+4. Produce an advisory report with executive summary, team consensus,
+   dissenting views, supporting evidence, risks, next steps, and
+   conflict resolutions
+5. Write your complete advisory synthesis to
+   /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-q2AEa6/gh-about-section-proposal/phase3-synthesis.md

--- a/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase3-synthesis.md
+++ b/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/phase3-synthesis.md
@@ -1,0 +1,170 @@
+# Advisory Report
+
+**Question**: What should the GitHub "About" section (description, website, topics) contain for the despicable-agents repository?
+**Confidence**: HIGH
+**Recommendation**: Use a concise, front-loaded description based on the README opening line; leave the website blank; apply 8 carefully selected topics balancing niche precision with ecosystem discovery.
+
+## Executive Summary
+
+Four specialists (product-marketing-minion, seo-minion, ux-strategy-minion, lucy) converged on the same core recommendations with strong consensus. The description should lead with what the project IS ("specialist agent team for Claude Code"), include the agent count (27) as a scope signal, and highlight governance gates as the primary differentiator -- the one feature no competitor leads with. The website field should be left blank (unanimous). Topics should number 8-10, anchored by `claude-code` and `ai-agents`, with niche terms like `claude-agents` and `agent-orchestration` for precision targeting.
+
+The primary tension is between a short, scannable description (~106 characters, ux-strategy-minion) and a longer, information-dense one (~299 characters, product-marketing-minion). Both are well-reasoned, and the choice depends on whether you optimize for instant pattern-matching or for search-result persuasion. The recommendation below provides both options with a clear pick.
+
+Confidence is HIGH because: all four specialists independently arrived at compatible recommendations, the project's canonical documents are internally consistent (giving a solid foundation), and the decision is easily reversible (the About section can be changed at any time via the GitHub UI).
+
+## Team Consensus
+
+All four specialists agreed on the following points without exception:
+
+1. **Lead with "specialist agent team for Claude Code"** (or close variant). This phrase appears in CLAUDE.md, README.md, and architecture.md. It is the project's established self-description and places the repo in the reader's mental model within 2 seconds.
+
+2. **Governance gates are the primary differentiator.** No competing repo (wshobson/agents, ruvnet/claude-flow, VoltAgent) leads with mandatory review before execution. This is the strongest positioning axis.
+
+3. **Website field: leave blank.** The README is the landing page. A URL pointing back to the repo or a specific doc file adds no value and creates maintenance burden. When a dedicated docs site exists (YAGNI -- not now), add it then.
+
+4. **Keep the description purely functional.** The repo name "despicable-agents" already carries the personality. The description should not lean into the Despicable Me theming. "Fun names, serious descriptions" (product-marketing-minion) matches "let the name carry personality, let the description carry information" (ux-strategy-minion).
+
+5. **Include the exact agent count (27).** Cited in every canonical document. Signals maturity and scope. Creates a maintenance obligation when the roster changes, but precision builds trust and matches existing convention.
+
+6. **`claude-code` is the most important topic.** Unanimous first pick. 6,003 repos, exact platform match, every comparable project uses it.
+
+7. **Avoid `framework`, `autonomous-agents`, `automation`, `ai-framework`.** The project is not a framework (no SDK, no library). Agents are not autonomous (human approval gates). "Automation" implies autonomy the project deliberately avoids.
+
+8. **Do not introduce new terminology.** The About section should echo language already established in canonical documents, not invent new framing (lucy's constraint, endorsed by all).
+
+## Dissenting Views
+
+### Description length: short vs. long
+
+- **ux-strategy-minion** recommends a 106-character description: "Specialist agent team for Claude Code -- 27 domain experts with orchestration and governance gates." Rationale: first 100 characters must be self-sufficient because GitHub truncates in search results and sidebar. Everything essential fits in one non-truncated line.
+
+- **product-marketing-minion** recommends a 299-character description: "27 specialist agents for Claude Code with phased orchestration and governance gates. Domain experts for security, testing, API design, infrastructure, and more -- each with strict boundaries. Five mandatory reviewers check every plan before code runs. Install once, use in any project." Rationale: the longer version earns more search keyword surface, lists concrete domains for pattern-matching, and makes the "five mandatory reviewers" claim -- the strongest trust signal.
+
+- **Resolution**: Both are viable. The short version is the safer default because it fits entirely within GitHub's non-truncated display zone (~100-120 chars) and delivers the complete message in every context. The long version adds real value (domain list, reviewer count, install convenience) but the incremental information appears only on the repo page sidebar, not in search results. **Recommend the short version as primary, with the long version as an alternative if the owner wants maximum information density.**
+
+### Topic count: 5-7 vs. 8 vs. 10
+
+- **lucy** recommends 5-7 topics, prioritizing only verified-accurate terms. Conservative approach minimizes risk of aspirational or misleading tags.
+- **product-marketing-minion** recommends 8 topics. Balanced between discovery and dilution.
+- **seo-minion** recommends 10 topics across three tiers. Maximizes coverage of platform, domain, and ecosystem discovery channels.
+
+- **Resolution**: 8 topics is the right balance. seo-minion's Tier 1 and Tier 2 topics are all verified-accurate (satisfying lucy's constraint). Two of the Tier 3 topics (`anthropic`, `developer-tools`) are also verified-accurate. The remaining two Tier 3 picks (`agent-teams`, `prompt-engineering`) are borderline -- `agent-teams` may not exist as an established topic yet, and `prompt-engineering` describes a secondary attribute. Dropping those two and keeping 8 topics satisfies all four specialists' reasoning.
+
+### Whether to include `claude` as a topic
+
+- **seo-minion** deliberately excludes `claude` (overlaps with `claude-code` and `anthropic`; at 6,927 repos it is large but undifferentiated).
+- **ux-strategy-minion** includes `claude` at position 5 (broader ecosystem discovery).
+- **product-marketing-minion** includes `claude` at position 4.
+
+- **Resolution**: Include `claude`. At 6,927 repos it is the second-largest relevant ecosystem after `ai-agents`. The overlap concern is valid but the cost of including it is zero (it occupies one topic slot of 20 available). Developers browsing the `claude` topic page are exactly the target audience. seo-minion's own analysis shows every top comparable project includes either `claude` or `anthropic` or both.
+
+### Whether to include `prompt-engineering`
+
+- **seo-minion** includes it (Tier 2, position 7). Rationale: each agent is a crafted system prompt backed by RESEARCH.md files; developers interested in prompt design patterns would study this repo.
+- **lucy** lists it as "Accurate" (verified against codebase).
+- **product-marketing-minion** and **ux-strategy-minion** do not include it.
+
+- **Resolution**: Exclude. While technically accurate, `prompt-engineering` as a topic would attract an audience looking for prompt templates and techniques, not an agent team. The project contains prompts but IS NOT a prompt engineering resource. Including it risks misaligned expectations. This follows lucy's principle: topics should reflect what the project IS, not what it contains.
+
+## Supporting Evidence
+
+### Product Marketing Analysis
+
+product-marketing-minion provided competitive landscape analysis showing the three main competitors (wshobson/agents, ruvnet/claude-flow, VoltAgent/awesome-claude-code-subagents) all position on agent count and orchestration breadth. None lead with governance. This confirms governance gates as an uncontested positioning axis.
+
+The "fun names, serious descriptions" principle is well-grounded: Terraform, Kubernetes, and Grafana all pair memorable/unusual names with purely functional descriptions. The pattern works because the name catches attention and the description converts it to understanding.
+
+Three candidate descriptions were provided with detailed trade-off analysis. Candidate A (299 chars) is the richest. Candidate C introduces agent hierarchy vocabulary (Nefario, minion) which could reduce onboarding friction but risks initial confusion.
+
+### SEO/Discovery Analysis
+
+seo-minion provided the most detailed topic ecosystem research, with repository counts for every relevant topic. Key data points:
+- `claude-code`: 6,003 repos (high relevance, primary discovery channel)
+- `ai-agents`: 9,338 repos (broad but relevant)
+- `claude-agents`: 38 repos (very niche, early presence opportunity)
+- `agent-orchestration`: 184 repos (niche, precisely targeted)
+- `llm`: 39,092 repos (too broad, excluded)
+
+The competitive topic analysis revealed that all successful comparable repos include `claude-code` and at least one of `anthropic` or `claude`. The recommendation to lean niche over broad is sound for a project targeting Claude Code users specifically.
+
+### UX Strategy Analysis
+
+ux-strategy-minion grounded the description in cognitive science: the "satisficing" two-stage pattern (pattern match in <2s, then value assessment in 1-3s). This explains why leading with "specialist agent team for Claude Code" outperforms leading with the problem or the solution -- it enables instant categorization.
+
+The 100-character truncation threshold analysis is practical and actionable. The recommended 106-character description fits almost entirely within the non-truncated zone, meaning the complete message survives across all GitHub display contexts.
+
+The theming analysis ("net neutral to slightly positive") with the constraint that the description must NOT lean into the theming aligns perfectly with product-marketing-minion's "fun names, serious descriptions" principle.
+
+### Governance/Consistency Analysis
+
+lucy verified that the project's self-description is remarkably consistent across all canonical documents (CLAUDE.md, README.md, architecture.md). All three use "specialist agent team," all cite 27 agents, all mention Claude Code. This consistency makes the About description straightforward -- reuse existing language rather than inventing new framing.
+
+The accuracy audit of potential topics is the most conservative and rigorous of the four contributions. lucy's "Accurate" / "Borderline" / "Avoid" classification provides a hard constraint that filters out aspirational or misleading topics. The four "Avoid" exclusions (`framework`, `autonomous-agents`, `automation`, `mcp`) are well-reasoned and endorsed by all other specialists.
+
+## Risks and Caveats
+
+1. **Agent count staleness.** The description will say "27 agents" and "27 domain experts." If agents are added or removed, the description becomes inaccurate. All four specialists flagged this. Mitigation: keep the exact number (consistent with README convention) and update it when the roster changes. The maintenance cost is low (one number in one field).
+
+2. **Emerging topic instability.** `claude-agents` (38 repos) and `agent-orchestration` (184 repos) are small topics. They may never gain traction. Mitigation: the cost of including them is zero. If they grow, early presence pays off. If they stagnate, they can be swapped out. seo-minion recommends revisiting topics quarterly.
+
+3. **GitHub character limit uncertainty.** The 350-character limit is based on available evidence but has changed historically. All recommended descriptions are well under 300 characters. The short option (106 chars) is immune to any reasonable limit change.
+
+4. **Governance claim verification.** product-marketing-minion flagged that the description claims governance gates are mandatory. If a developer installs the tool and finds this is easily bypassed or not enforced, trust erodes. The claim is accurate (five mandatory reviewers are documented and enforced in the nefario skill), but worth verifying before publishing.
+
+5. **Number comparison with competitors.** wshobson/agents advertises 112 agents; VoltAgent advertises 100+. "27 agents" may invite unfavorable quantity comparison. Mitigation: the description couples the number with "governance gates" and "domain experts" -- signaling quality over quantity. This is a feature, not a weakness, but some readers will skim past the differentiator and focus on the number.
+
+## Next Steps
+
+If the recommendation is adopted, implementation is a single GitHub UI or CLI operation:
+
+1. **Set the description** using one of the two recommended options (see Conflict Resolutions for the final candidates).
+
+2. **Set the topics** (in this order): `claude-code`, `ai-agents`, `agent-orchestration`, `claude`, `multi-agent`, `claude-agents`, `developer-tools`, `anthropic`.
+
+3. **Leave the website field blank.**
+
+4. **Verify** the description displays correctly in: (a) the repo sidebar, (b) GitHub search results for "claude code agents", (c) the organization/user profile if the repo is pinned.
+
+This can be done via the GitHub UI (Settings > General > About section) or via the GitHub API / `gh` CLI:
+
+```bash
+gh repo edit --description "Specialist agent team for Claude Code -- 27 domain experts with orchestration and governance gates."
+gh repo edit --add-topic claude-code --add-topic ai-agents --add-topic agent-orchestration --add-topic claude --add-topic multi-agent --add-topic claude-agents --add-topic developer-tools --add-topic anthropic
+```
+
+No branch, PR, or code changes are needed. The About section is repo metadata, not a tracked file.
+
+## Conflict Resolutions
+
+### Description length (primary conflict)
+
+ux-strategy-minion and product-marketing-minion proposed descriptions of significantly different lengths (106 vs. 299 characters). Both are well-reasoned with different optimization targets.
+
+**Resolution**: Recommend the short description as the primary choice, with the long description as an explicit alternative.
+
+**Primary recommendation (106 chars):**
+> Specialist agent team for Claude Code -- 27 domain experts with orchestration and governance gates.
+
+**Alternative (299 chars):**
+> 27 specialist agents for Claude Code with phased orchestration and governance gates. Domain experts for security, testing, API design, infrastructure, and more -- each with strict boundaries. Five mandatory reviewers check every plan before code runs. Install once, use in any project.
+
+Rationale for preferring short: it survives truncation in all GitHub display contexts, matches the README's concise style, and the repo name + README already handle the longer pitch. The short version is complete -- it answers what (specialist agent team), where (Claude Code), how many (27), and why it is different (orchestration + governance gates). The long version adds valuable detail but that detail is available one click away in the README.
+
+### Topic set composition (minor conflict)
+
+Four different topic lists were proposed, ranging from 5-7 (lucy) to 10 (seo-minion). Specific disagreements on `claude`, `prompt-engineering`, `code-review`, `code-quality`, `ai-coding`, and `claude-skills`.
+
+**Resolution**: 8 topics, selected by applying lucy's accuracy constraint to seo-minion's ecosystem data, then filtering through product-marketing-minion's discovery priorities:
+
+| # | Topic | Source Agreement |
+|---|-------|-----------------|
+| 1 | `claude-code` | All four |
+| 2 | `ai-agents` | All four |
+| 3 | `agent-orchestration` | product-marketing, seo, ux-strategy |
+| 4 | `claude` | product-marketing, ux-strategy (seo excluded it; adding back per resolution above) |
+| 5 | `multi-agent` | product-marketing, seo, ux-strategy |
+| 6 | `claude-agents` | seo (niche early-presence play; verified accurate by lucy) |
+| 7 | `developer-tools` | product-marketing, seo, ux-strategy |
+| 8 | `anthropic` | seo, ux-strategy, lucy |
+
+Excluded from seo-minion's list: `claude-skills` (the project includes skills but IS NOT primarily a skills project), `prompt-engineering` (attracts wrong audience), `agent-teams` (may not exist as established topic yet). These can be reconsidered if the ecosystem evolves.

--- a/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal/prompt.md
@@ -1,0 +1,1 @@
+Propose description, website, topics for the GH about section of the repo.


### PR DESCRIPTION
## Summary

- Advisory orchestration recommending description, website, and topics for the GitHub About section
- 4 specialists consulted: product-marketing-minion, seo-minion, ux-strategy-minion, lucy
- Unanimous consensus on short description, 8 topics, blank website

## Report

`docs/history/nefario-reports/2026-02-13-114622-gh-about-section-proposal.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)