### PR TITLE
docs: cross-platform compatibility advisory report

### DIFF
--- a/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check.md
+++ b/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check.md
@@ -1,0 +1,208 @@
+---
+type: nefario-report
+version: 3
+date: "2026-02-13"
+time: "14:26:12"
+task: "Cross-platform compatibility audit and documentation recommendations"
+mode: advisory
+agents-involved: [nefario, iac-minion, devx-minion, software-docs-minion, security-minion]
+task-count: 0
+gate-count: 0
+outcome: completed
+---
+
+# Cross-platform compatibility audit and documentation recommendations
+
+## Summary
+
+Four specialists audited the despicable-agents shell scripts, hook scripts, SKILL.md bash snippets, and symlink-based deployment model for cross-platform compatibility. The project is NOT cross-platform safe today: it works on macOS (with Homebrew bash) and Linux, but stock macOS has a latent bash 3.2 bug in the commit hooks, and Windows is unsupported due to POSIX symlink dependencies. The team recommends documentation first (platform disclaimers, prerequisites page, Claude Code setup prompt), deferring code changes per YAGNI.
+
+## Original Prompt
+
+> check if we are fine on all platforms and if not, what it would take to be safe on windows, macOS, linux
+> we should think about adding documentation disclaimers that this is mac-only until we have that fixed (if the answer is "not yet")
+> also think about documenting all command line tools that are expected to be available
+> in the report, include prompts for
+> - the docs disclaimer for platform specificity for now
+> - documentation on required command line tools and how to install them ("ask claude code to do it for you, just paste the list")
+> - achieving cross-platform stability
+
+## Key Design Decisions
+
+#### Documentation First, Code Changes Later
+
+**Rationale**:
+- Consistent with the project's YAGNI/KISS philosophy from CLAUDE.md
+- No evidence of Windows users hitting issues yet
+- Documentation has high value (prevents confusion) with low effort
+- Code hardening can be done independently when demand materializes
+
+**Alternatives Rejected**:
+- Immediate bash 3.2 fix + temp path standardization: deferred as Tier 2 (no user reports of breakage yet)
+- Windows copy-based fallback in install.sh: deferred as Tier 3 (YAGNI -- no Windows users yet)
+
+#### WSL as Recommended Windows Path (Not Git Bash)
+
+**Rationale**:
+- WSL provides full POSIX semantics with zero code changes
+- Git Bash has fundamental limitations: symlinks become copies (breaking live-editing), chmod is a no-op, jq not bundled
+- security-minion confirmed WSL preserves the full security model (chmod works, symlinks work)
+
+**Alternatives Rejected**:
+- Git Bash as primary: degraded experience (copies instead of symlinks), silent security model degradation
+- Junction points on Windows: security-minion blocked -- junction traversal enables local privilege escalation
+- PowerShell install script: requires full rewrite, adds maintenance burden, hooks still need bash
+
+#### GitHub Issue for Cross-Platform Tracking (Not Docs Page)
+
+**Rationale**:
+- A roadmap in docs/ goes stale the moment work starts
+- GitHub issue with checklist is a living artifact that can be assigned and tracked
+- If a platform support decision is eventually made, that warrants an ADR
+
+**Alternatives Rejected**:
+- docs/cross-platform-roadmap.md: would go stale, no natural update trigger
+
+### Conflict Resolutions
+
+1. **Junction points**: iac-minion listed as an option for directory-level symlinks on Windows. security-minion blocked -- junction traversal is a real local privilege escalation vector. Resolved in favor of security-minion.
+
+2. **Immediacy of code changes**: iac-minion proposed 5 implementation tasks. devx-minion recommended Tier 1 docs only, deferring code. Resolved in favor of devx-minion's tiered approach -- consistent with YAGNI.
+
+3. **Prerequisites location**: software-docs-minion wanted standalone docs/prerequisites.md. devx-minion wanted inline README checklist. Resolved as complementary -- README gets a concise checklist, docs/prerequisites.md gets per-platform details.
+
+## Phases
+
+### Phase 1: Meta-Plan
+
+Nefario identified 4 specialists for the audit: iac-minion (shell script portability), devx-minion (developer experience and documentation format), software-docs-minion (documentation structure and placement), and security-minion (security implications of cross-platform adaptations). Scope was defined as all executable shell artifacts, embedded bash snippets in SKILL.md files, the symlink deployment model, and documentation. AGENT.md/RESEARCH.md content (pure markdown) and Claude Code platform support itself were excluded. Two project-local skills were discovered (despicable-lab, despicable-statusline) but neither was relevant to the advisory task.
+
+### Phase 2: Specialist Planning
+
+**iac-minion** performed a comprehensive audit of all shell scripts, identifying 17 platform-specific issues. The most critical finding: `commit-point-check.sh` uses bash 4+ features (associative arrays via `local -A`, array initialization via `local -a x=()`) that cause fatal syntax errors on stock macOS bash 3.2. Also identified 6+ locations where temp paths hardcode `/tmp/` instead of `${TMPDIR:-/tmp}`, and catalogued all 12 external tool dependencies across the scripts.
+
+**devx-minion** focused on how to communicate platform requirements. Recommended a 3-tier approach: Tier 1 (documentation now), Tier 2 (script hardening when needed), Tier 3 (true cross-platform, likely YAGNI). Provided the "paste into Claude Code" setup prompt concept and recommended framing as "tested on macOS and Linux" rather than "macOS/Linux only."
+
+**software-docs-minion** recommended two-location disclaimers (README + deployment.md), a new standalone docs/prerequisites.md, and a GitHub tracking issue rather than a docs-page roadmap. Emphasized that the macOS bash 3.2 problem is a latent bug today, not just a future Windows concern.
+
+**security-minion** analyzed the security implications of cross-platform temp file handling, permission models, and symlink alternatives. Key findings: chmod is a no-op on Windows NTFS (creating a fail-open condition), the fail-closed design in sensitive-patterns.txt is safe cross-platform (uses bash built-ins not grep), and junction points on Windows are a security risk (traversal attacks). Confirmed WSL as the safe path for Windows users.
+
+### Phase 3: Synthesis
+
+All four specialists reached strong consensus: the project works on macOS (with Homebrew bash) and Linux, stock macOS has a latent bug, and Windows is unsupported. The recommendation is documentation first, code changes later. The synthesis resolved three minor conflicts (junction safety, code change timing, prerequisites location) and produced three ready-to-use prompts for the user's requested deliverables.
+
+### Phase 3.5: Architecture Review
+
+Skipped (advisory-only orchestration).
+
+### Phase 4: Execution
+
+Skipped (advisory-only orchestration).
+
+### Phase 5: Code Review
+
+Skipped (advisory-only orchestration).
+
+### Phase 6: Test Execution
+
+Skipped (advisory-only orchestration).
+
+### Phase 7: Deployment
+
+Skipped (advisory-only orchestration).
+
+### Phase 8: Documentation
+
+Skipped (advisory-only orchestration).
+
+## Agent Contributions
+
+<details>
+<summary>Agent Contributions (4 planning)</summary>
+
+### Planning
+
+**iac-minion**: Comprehensive shell script audit identifying 17 platform issues across macOS, Linux, and Windows. Key finding: commit-point-check.sh uses bash 4+ features fatal on stock macOS.
+- Adopted: Platform issues inventory, external tool dependency catalog, POSIX alternatives for bash 4+ features, temp path inconsistency analysis
+- Risks flagged: Hook path coordination (high) -- coupled temp paths across files; jq undocumented hard dependency (high) -- silent failures; Windows symlinks fundamentally limited
+
+**devx-minion**: Developer experience analysis with tiered approach to cross-platform stability. Provided ready-to-use documentation copy and the "paste into Claude Code" setup prompt concept.
+- Adopted: 3-tier approach (docs now, hardening later, true cross-platform deferred), "tested on macOS and Linux" framing, flat checklist format for prerequisites, Claude Code setup prompt
+- Risks flagged: bash 3.2 silent failures on macOS, jq hidden dependency, Windows symlink model fundamentally incompatible
+
+**software-docs-minion**: Documentation structure and placement strategy. Recommended two-location disclaimers, standalone prerequisites page, and GitHub issue for cross-platform tracking.
+- Adopted: Two-location disclaimer strategy (README + deployment.md), standalone docs/prerequisites.md, GitHub issue for roadmap (not docs page), architecture.md table update
+- Risks flagged: macOS bash 3.2 is latent bug today, documentation drift risk, overloading README
+
+**security-minion**: Security analysis of cross-platform temp file handling, permission models, and symlink alternatives. Confirmed fail-closed design is safe, blocked junction points as insecure.
+- Adopted: WSL as recommended Windows path, no junctions (traversal attack risk), CRLF normalization recommendation, chmod security model analysis
+- Risks flagged: Silent security degradation on Windows (chmod no-op = fail-open), enterprise Windows blocks symlinks via group policy, session ID in predictable temp paths
+
+</details>
+
+## Team Recommendation
+
+**Document the current state honestly (macOS + Linux supported, Windows not yet), defer code changes per YAGNI, and provide ready-to-use prompts for future hardening work.**
+
+### Consensus
+
+| Position | Agents | Strength |
+|----------|--------|----------|
+| Documentation first, code later | all 4 specialists | Strong -- unanimous, consistent with project philosophy |
+| WSL as recommended Windows path | security-minion, devx-minion, iac-minion | Strong -- full POSIX semantics, zero code changes |
+| No junction points on Windows | security-minion | Strong -- junction traversal is a real attack vector |
+| macOS bash 3.2 is a latent bug today | iac-minion, devx-minion, software-docs-minion | Strong -- independently identified by 3 of 4 specialists |
+
+### When to Revisit
+
+1. A user reports that hooks fail on stock macOS (bash 3.2) -- triggers Tier 2 script hardening
+2. A Windows user opens an issue asking for support -- triggers evaluation of WSL-only vs. copy-based fallback
+3. The project gains CI -- triggers adding shellcheck and cross-platform matrix testing
+4. The project gains contributors on Windows -- triggers architectural decision on deployment model
+
+### Strongest Arguments
+
+**For documentation first** (adopted):
+
+| Argument | Agent |
+|----------|-------|
+| Consistent with YAGNI/KISS philosophy in CLAUDE.md | devx-minion |
+| No evidence of users hitting these issues yet | devx-minion |
+| Documentation prevents confusion with zero risk of regressions | software-docs-minion |
+| The bash 3.2 bug is real but likely mitigated by Homebrew prevalence | iac-minion |
+
+**For immediate code hardening** (not adopted, but preserved):
+
+| Argument | Agent |
+|----------|-------|
+| bash 4+ fix is small (POSIX alternatives exist for every construct) | iac-minion |
+| Silent failures are worse than explicit failures -- users don't know hooks are broken | iac-minion |
+| $TMPDIR standardization prevents a class of future bugs atomically | iac-minion |
+| chmod no-op on Windows is a fail-open security condition | security-minion |
+
+## Working Files
+
+<details>
+<summary>Working files (13 files)</summary>
+
+Companion directory: [2026-02-13-142612-cross-platform-compatibility-check/](./2026-02-13-142612-cross-platform-compatibility-check/)
+
+- [Original Prompt](./2026-02-13-142612-cross-platform-compatibility-check/prompt.md)
+
+**Outputs**
+- [Phase 1: Meta-plan](./2026-02-13-142612-cross-platform-compatibility-check/phase1-metaplan.md)
+- [Phase 2: iac-minion](./2026-02-13-142612-cross-platform-compatibility-check/phase2-iac-minion.md)
+- [Phase 2: devx-minion](./2026-02-13-142612-cross-platform-compatibility-check/phase2-devx-minion.md)
+- [Phase 2: software-docs-minion](./2026-02-13-142612-cross-platform-compatibility-check/phase2-software-docs-minion.md)
+- [Phase 2: security-minion](./2026-02-13-142612-cross-platform-compatibility-check/phase2-security-minion.md)
+- [Phase 3: Synthesis](./2026-02-13-142612-cross-platform-compatibility-check/phase3-synthesis.md)
+
+**Prompts**
+- [Phase 1: Meta-plan prompt](./2026-02-13-142612-cross-platform-compatibility-check/phase1-metaplan-prompt.md)
+- [Phase 2: iac-minion prompt](./2026-02-13-142612-cross-platform-compatibility-check/phase2-iac-minion-prompt.md)
+- [Phase 2: devx-minion prompt](./2026-02-13-142612-cross-platform-compatibility-check/phase2-devx-minion-prompt.md)
+- [Phase 2: software-docs-minion prompt](./2026-02-13-142612-cross-platform-compatibility-check/phase2-software-docs-minion-prompt.md)
+- [Phase 2: security-minion prompt](./2026-02-13-142612-cross-platform-compatibility-check/phase2-security-minion-prompt.md)
+- [Phase 3: Synthesis prompt](./2026-02-13-142612-cross-platform-compatibility-check/phase3-synthesis-prompt.md)
+
+</details>

--- a/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase1-metaplan-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase1-metaplan-prompt.md
@@ -1,0 +1,38 @@
+MODE: META-PLAN
+
+You are creating a meta-plan — a plan for who should help plan.
+
+## Task
+check if we are fine on all platforms and if not, what it would take to be safe on windows, macOS, linux
+we should think about adding documentation disclaimers that this is mac-only until we have that fixed (if the answer is "not yet")
+also think about documenting all command line tools that are expected to be available
+in the report, include prompts for
+- the docs disclaimer for platform specificity for now
+- documentation on required command line tools and how to install them ("ask claude code to do it for you, just paste the list")
+- achieving cross-platform stability
+
+## Working Directory
+/Users/ben/github/benpeter/despicable-agents
+
+## External Skill Discovery
+Before analyzing the task, scan for project-local skills. If skills are
+discovered, include an "External Skill Integration" section in your meta-plan
+(see your Core Knowledge for the output format).
+
+## Instructions
+1. Read relevant files to understand the codebase context
+2. Discover external skills:
+   a. Scan .claude/skills/ and .skills/ in the working directory for SKILL.md files
+   b. Read frontmatter (name, description) for each discovered skill
+   c. For skills whose description matches the task domain, classify as
+      ORCHESTRATION or LEAF (see External Skill Integration in your Core Knowledge)
+   d. Check the project's CLAUDE.md for explicit skill preferences
+   e. Include discovered skills in your meta-plan output
+3. Analyze the task against your delegation table
+4. Identify which specialists should be CONSULTED FOR PLANNING
+   (not execution — planning). These are agents whose domain
+   expertise is needed to create a good plan.
+5. For each specialist, write a specific planning question that
+   draws on their unique expertise.
+6. Return the meta-plan in the structured format.
+7. Write your complete meta-plan to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-W2FlrM/cross-platform-compatibility-check/phase1-metaplan.md`

--- a/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase1-metaplan.md
+++ b/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase1-metaplan.md
@@ -1,0 +1,146 @@
+# Phase 1: Meta-Plan -- Cross-Platform Compatibility Check
+
+## Task Summary
+
+Audit all executable artifacts in despicable-agents (shell scripts, hook scripts,
+SKILL.md bash snippets, deployment model) for cross-platform compatibility across
+macOS, Linux, and Windows. Determine current platform support status. Produce:
+1. An assessment of what works/breaks on each platform
+2. Documentation disclaimers for current platform specificity
+3. Documentation of required command-line tools with install instructions
+4. A roadmap for achieving cross-platform stability
+
+## Scope
+
+**In scope:**
+- `install.sh` (deployment script)
+- `.claude/hooks/track-file-changes.sh` (PostToolUse hook)
+- `.claude/hooks/commit-point-check.sh` (Stop hook)
+- `.claude/hooks/sensitive-patterns.txt` (consumed by hooks)
+- `.claude/settings.json` (hook registration, env vars)
+- `skills/nefario/SKILL.md` (bash snippets for scratch dirs, status files)
+- `skills/despicable-prompter/SKILL.md` (mktemp usage)
+- `.claude/skills/despicable-lab/SKILL.md` (project-local skill)
+- `.claude/skills/despicable-statusline/SKILL.md` (jq dependency)
+- `the-plan.md` deployment section (`realpath` usage)
+- `docs/deployment.md` (deployment documentation)
+- `README.md` (install instructions, limitations section)
+- Symlink-based deployment model (fundamental architecture)
+
+**Out of scope:**
+- AGENT.md content (pure markdown, platform-independent)
+- RESEARCH.md content (not deployed)
+- Agent system prompt logic (runs inside Claude Code, not OS-level)
+- Claude Code platform support itself (Anthropic's responsibility)
+
+## Initial Platform Concern Inventory
+
+### Identified Issues (from codebase scan)
+
+| # | File | Concern | macOS | Linux | Windows |
+|---|------|---------|-------|-------|---------|
+| 1 | `install.sh` | `ln -sf` symlinks | OK | OK | Broken (requires admin/dev mode, different syntax) |
+| 2 | `install.sh` | `readlink` (no `-f` flag on macOS) | OK (used without `-f`) | OK | N/A (no readlink) |
+| 3 | `install.sh` | `BASH_SOURCE[0]` | OK (bash 3.2+) | OK | Needs bash (Git Bash or WSL) |
+| 4 | `install.sh` | ANSI color codes (`\033[...`) | OK | OK | Partial (Windows Terminal OK, cmd.exe broken) |
+| 5 | hooks/*.sh | `#!/usr/bin/env bash` shebang | OK | OK | Broken natively; needs Git Bash/WSL |
+| 6 | hooks/*.sh | `local -a` (indexed arrays) | OK | OK | Needs bash 4+ |
+| 7 | hooks/*.sh | `local -A` (associative arrays) | Needs bash 4+ (macOS ships 3.2!) | OK (bash 5+) | Needs bash 4+ |
+| 8 | hooks/*.sh | `jq` dependency | Not preinstalled | Not preinstalled | Not preinstalled |
+| 9 | hooks/*.sh | Hardcoded `/tmp/` paths | OK | OK | Broken (no /tmp/ natively) |
+| 10 | hooks/*.sh | `grep -qFx` flags | OK | OK | Needs GNU grep or equivalent |
+| 11 | SKILL.md | `mktemp -d` with template | OK | OK | Broken natively |
+| 12 | SKILL.md | `${TMPDIR:-/tmp}` | OK | OK | Partial ($TMPDIR may differ) |
+| 13 | SKILL.md | `chmod 700` / `chmod 600` | OK | OK | No-op or broken on NTFS |
+| 14 | the-plan.md | `realpath` in deployment snippets | Not preinstalled (need coreutils) | OK | Broken natively |
+| 15 | settings.json | `$CLAUDE_PROJECT_DIR` in hook commands | OK | OK | Shell expansion may differ |
+| 16 | Deployment model | Symlinks as core architecture | OK | OK | Fundamentally problematic |
+| 17 | statusline skill | `command -v jq` dependency check | OK | OK | Needs bash environment |
+
+### Key Observation
+
+**macOS has a bash 3.2 problem.** The hook scripts use `local -A` (associative
+arrays), which requires bash 4+. macOS ships bash 3.2 (2007) due to GPLv3
+licensing. Users who installed bash via Homebrew have bash 5+ at
+`/usr/local/bin/bash` or `/opt/homebrew/bin/bash`, but `#!/usr/bin/env bash`
+resolves to the system bash 3.2 unless PATH is configured. This means hooks
+may already be broken on stock macOS.
+
+---
+
+## Planning Consultations
+
+### Consultation 1: Shell Script Cross-Platform Audit
+
+- **Agent**: iac-minion
+- **Planning question**: Given the three shell scripts (`install.sh`, `track-file-changes.sh`, `commit-point-check.sh`) and the bash snippets embedded in SKILL.md files, what is the minimal set of changes needed to support macOS (including stock bash 3.2), Linux, and Windows (Git Bash / WSL)? Specifically: (a) Can we avoid bash 4+ features in hooks to support stock macOS? (b) What is the Windows story -- do we target Git Bash, WSL, or PowerShell? (c) Should we use `$TMPDIR` consistently instead of hardcoded `/tmp/`? (d) What is the cross-platform equivalent for symlinks on Windows -- junctions, mklink, or copy-based deployment? (e) Are there POSIX-only alternatives for the bash-specific features used?
+- **Context to provide**: `install.sh`, `.claude/hooks/track-file-changes.sh`, `.claude/hooks/commit-point-check.sh`, `.claude/settings.json`, the bash snippets from `skills/nefario/SKILL.md` (lines 257-270, 375-396), `the-plan.md` deployment section (lines 1604-1625)
+- **Why this agent**: iac-minion has deep expertise in shell scripting, Docker, CI/CD, and infrastructure automation across platforms. This is fundamentally an infrastructure portability question.
+
+### Consultation 2: Developer Experience for Multi-Platform Setup
+
+- **Agent**: devx-minion
+- **Planning question**: How should we document platform requirements and installation prerequisites for a tool that currently targets macOS/Linux with bash? Consider: (a) What is the right format for a "prerequisites" section -- table, checklist, or platform-specific tabs? (b) Should we provide a "check prerequisites" script or command? (c) How should we communicate "macOS-only for now" without making the project look immature? (d) What is the best way to document required CLI tools (git, jq, bash 4+, gh) with install instructions that work across package managers (brew, apt, dnf, choco, winget)? (e) The user wants an approach like "just paste this list and ask Claude Code to install them" -- is that viable and how should we format it?
+- **Context to provide**: Current `README.md` (especially Install section and Current Limitations), `docs/deployment.md`, the list of identified external dependencies (bash 4+, jq, git, gh CLI, realpath/coreutils)
+- **Why this agent**: devx-minion specializes in developer onboarding, CLI design, error messages, and making tooling approachable. The documentation and prerequisite communication is a developer experience challenge.
+
+### Consultation 3: Documentation Strategy
+
+- **Agent**: software-docs-minion
+- **Planning question**: We need to produce three documentation artifacts: (a) A platform support disclaimer for README.md and docs (what format, where to place it, how to phrase it for an open-source project that is currently macOS/Linux-only), (b) A prerequisites/dependencies page documenting all required CLI tools with per-platform install instructions, (c) A "cross-platform roadmap" section or tracking issue format for the path to Windows support. How should these integrate with the existing docs structure (README.md -> docs/architecture.md hub -> sub-docs)? Should the prerequisites doc be standalone or part of deployment.md?
+- **Context to provide**: `README.md`, `docs/architecture.md` (sub-documents table), `docs/deployment.md`, identified platform issues inventory
+- **Why this agent**: software-docs-minion handles architecture documentation, README structure, and documentation organization. This is a documentation structure and placement question.
+
+### Consultation 4: Security Review of Platform Mitigations
+
+- **Agent**: security-minion
+- **Planning question**: The hook scripts and SKILL.md use `mktemp -d` with `chmod 700` for scratch directories and `/tmp/` for session state files. If we make these cross-platform: (a) Are there security implications of using `$TMPDIR` on Windows (less restrictive permissions model)? (b) The current `chmod 600`/`chmod 700` calls are security controls -- what replaces them on Windows/NTFS? (c) The `sensitive-patterns.txt` fail-closed design -- does it remain safe if `grep` behavior differs across platforms? (d) Any concerns with the symlink-to-junction migration path on Windows?
+- **Context to provide**: `.claude/hooks/commit-point-check.sh` (especially the security-relevant sections: sensitive file filtering, fail-closed pattern, tmp file paths), `.claude/hooks/track-file-changes.sh` (path injection validation), `skills/nefario/SKILL.md` scratch directory section
+- **Why this agent**: security-minion reviews threat models and identifies risks in infrastructure changes. Cross-platform temp file handling and permission models are security-sensitive.
+
+### Cross-Cutting Checklist
+
+- **Testing**: Include test-minion for planning? **No** -- this is an advisory/audit task, not producing executable code. Testing concerns (e.g., "how would we test cross-platform?") are covered by iac-minion's CI/CD expertise. If this moves to execution, test-minion would be involved.
+- **Security**: **Yes** -- included as Consultation 4. Temp file handling, permission models, and symlink security on Windows are genuine security concerns.
+- **Usability -- Strategy**: **Yes** -- partially covered by devx-minion (Consultation 2) who handles developer onboarding UX. A separate ux-strategy-minion consultation is not needed because the "users" here are developers installing a CLI tool, which falls squarely in devx-minion's domain. ux-strategy-minion's journey mapping expertise is not additive for a developer tooling prerequisite audit.
+- **Usability -- Design**: **No** -- no user-facing interfaces are being produced. This is documentation and shell script analysis.
+- **Documentation**: **Yes** -- included as Consultation 3 (software-docs-minion). user-docs-minion is not needed separately because the audience is developers/contributors, not end-users of a product.
+- **Observability**: **No** -- no runtime components are being created or modified.
+
+### Anticipated Approval Gates
+
+This is an advisory-mode task producing a report with recommendations and documentation prompts. The primary deliverable is the advisory report itself. No approval gates are anticipated because:
+
+1. The report produces recommendations, not code changes
+2. The documentation prompts are provided for the user to review and apply at their discretion
+3. No irreversible decisions are being made
+
+If the user decides to act on the cross-platform roadmap, that would be a separate `/nefario` execution session with its own gates.
+
+### Rationale
+
+Four specialists were selected because the task spans four distinct domains:
+
+1. **iac-minion** (primary): The core technical audit -- what breaks, what the fixes are, cross-platform shell scripting expertise
+2. **devx-minion**: How to communicate platform requirements to developers -- the UX of installation and prerequisites
+3. **software-docs-minion**: Where and how to place the documentation within the existing docs structure
+4. **security-minion**: Whether cross-platform adaptations introduce security regressions in the temp file and permission model
+
+Agents NOT consulted and why:
+- **debugger-minion**: No debugging needed -- this is analysis, not troubleshooting a failure
+- **frontend-minion**: No frontend components involved
+- **test-minion**: No test code being written in this advisory phase
+- **ux-strategy-minion**: Developer tooling UX is covered by devx-minion; no product UX journey involved
+
+### External Skill Integration
+
+#### Discovered Skills
+
+| Skill | Location | Classification | Domain | Recommendation |
+|-------|----------|---------------|--------|----------------|
+| despicable-lab | `.claude/skills/despicable-lab/` | LEAF | Agent build/rebuild pipeline | Not relevant -- this task does not rebuild agents |
+| despicable-statusline | `.claude/skills/despicable-statusline/` | LEAF | Claude Code status line config | Peripheral -- has a `jq` dependency worth noting in the prerequisites audit, but the skill itself is not needed for planning |
+
+#### Precedence Decisions
+
+No precedence conflicts. Neither discovered skill overlaps with the advisory task's domain.

--- a/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase2-devx-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase2-devx-minion-prompt.md
@@ -1,0 +1,57 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise
+to help build a comprehensive plan.
+
+## Project Task
+check if we are fine on all platforms and if not, what it would take to be safe on windows, macOS, linux
+we should think about adding documentation disclaimers that this is mac-only until we have that fixed (if the answer is "not yet")
+also think about documenting all command line tools that are expected to be available
+in the report, include prompts for
+- the docs disclaimer for platform specificity for now
+- documentation on required command line tools and how to install them ("ask claude code to do it for you, just paste the list")
+- achieving cross-platform stability
+
+## Your Planning Question
+How should we document platform requirements and installation prerequisites for a tool that currently targets macOS/Linux with bash? Consider:
+(a) What is the right format for a "prerequisites" section -- table, checklist, or platform-specific tabs?
+(b) Should we provide a "check prerequisites" script or command?
+(c) How should we communicate "macOS/Linux-only for now" without making the project look immature?
+(d) What is the best way to document required CLI tools (git, jq, bash 4+, gh) with install instructions that work across package managers (brew, apt, dnf, choco, winget)?
+(e) The user wants an approach like "just paste this list and ask Claude Code to install them" -- is that viable and how should we format it?
+
+## Context
+Read these files from the working directory /Users/ben/github/benpeter/despicable-agents:
+- `README.md` (especially Install section and Current Limitations)
+- `docs/deployment.md`
+- The list of identified external dependencies: bash 4+, jq, git, gh CLI, realpath/coreutils
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed
+into a team recommendation, not an execution plan. Focus on analysis,
+trade-offs, and recommendations rather than implementation tasks.
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. If you believe additional specialists should be involved that
+   aren't already part of the planning, say so and explain why
+5. Return your contribution in this format:
+
+## Domain Plan Contribution: devx-minion
+
+### Recommendations
+<your expert recommendations for this aspect of the task>
+
+### Proposed Tasks
+<specific tasks that should be in the execution plan>
+For each task: what to do, deliverables, dependencies
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why>
+(or "None" if the current team is sufficient)
+
+6. Write your complete contribution to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-W2FlrM/cross-platform-compatibility-check/phase2-devx-minion.md`

--- a/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase2-devx-minion.md
+++ b/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase2-devx-minion.md
@@ -1,0 +1,316 @@
+# Domain Plan Contribution: devx-minion
+
+## Recommendations
+
+### 1. Current Platform Status Assessment
+
+After auditing the codebase, here is the complete external dependency inventory and platform compatibility status.
+
+**External CLI tool dependencies:**
+
+| Tool | Used In | Required For | macOS | Linux | Windows (Git Bash) |
+|------|---------|--------------|-------|-------|---------------------|
+| `bash` 4+ | All `.sh` scripts | Associative arrays (`local -A`), indexed arrays (`local -a`) in `commit-point-check.sh` | Needs Homebrew (system bash is 3.2) | Ships with distro | Ships with Git for Windows (4.4+) |
+| `git` | Hook scripts, install.sh (uninstall) | Symlink verification, change tracking | Pre-installed or Xcode CLT | `apt install git` | Required by Claude Code on Windows |
+| `jq` | Both hook scripts | JSON parsing of hook input | `brew install jq` | `apt install jq` | Separate install needed |
+| `ln -sf` | install.sh | Symlink creation | Native | Native | Requires `MSYS=winsymlinks:nativestrict` or admin/Developer Mode |
+| `readlink` | install.sh (uninstall only) | Symlink target verification | BSD variant (no `--help`, no `-f`) | GNU variant | Git Bash includes MSYS2 version |
+| `grep` | track-file-changes.sh | Ledger deduplication | Native | Native | Git Bash includes |
+| `awk` | commit-point-check.sh | Diff line counting | Native | Native | Git Bash includes |
+| `gh` (GitHub CLI) | commit-point-check.sh (suggested, not required) | PR creation suggestion in commit checkpoint | `brew install gh` | `apt install gh` | `winget install GitHub.cli` |
+
+**Verdict: The core install path (install.sh) works on macOS and Linux today. Windows has a real symlink problem. The hook scripts additionally require jq and bash 4+.**
+
+### 2. Platform Compatibility Issues Found
+
+**Critical (blocks install on Windows):**
+
+- `ln -sf` in Git Bash on Windows creates **copies, not symlinks** by default. The entire deployment model depends on symlinks for live-editing. This is the single biggest blocker.
+- Workaround exists (`MSYS=winsymlinks:nativestrict` + Developer Mode), but it is non-obvious and fragile.
+
+**Moderate (breaks hooks on stock macOS):**
+
+- macOS ships with bash 3.2 (from 2007). The commit-point-check.sh uses `local -A` (associative arrays), a bash 4.0+ feature. Users who run Claude Code with the system bash will get silent hook failures.
+- `jq` is not pre-installed on any platform. Hooks silently fail without it (they trap errors and exit 0, which is safe but confusing).
+
+**Low (cosmetic):**
+
+- `readlink` on macOS is the BSD variant. The current usage (`readlink <path>` without `-f`) works correctly on all platforms -- no issue here.
+- Color codes in install.sh use ANSI escapes, which work in all modern terminals including Windows Terminal and Git Bash.
+
+### 3. Documentation Format Recommendations
+
+**(a) Prerequisites section format: Use a simple checklist, not tabs or a table.**
+
+Tables are good for comparison, but a prerequisites section is a "do you have these things" moment. A checklist with copy-pasteable verification commands is the right format. Platform-specific tabs add cognitive load for what should be a 30-second check.
+
+Recommended structure:
+```
+## Prerequisites
+
+- [ ] **Claude Code** -- [Install guide](https://code.claude.com/docs/en/setup)
+- [ ] **git** -- `git --version` (2.20+)
+- [ ] **jq** -- `jq --version` (1.6+, required for commit hooks)
+- [ ] **bash** 4+ -- `bash --version` (required for commit hooks)
+- [ ] **gh** (optional) -- `gh --version` (for PR creation from commit checkpoints)
+```
+
+Keep it flat. No tabs. Developers scan, they do not read.
+
+**(b) A "check prerequisites" script: Yes, but as a command, not a separate script.**
+
+Add `./install.sh check` as a third mode alongside `install` and `uninstall`. This keeps the single entry point and follows the pattern users already know. The check command should:
+
+1. Verify each tool exists and meets minimum version
+2. Print pass/fail per tool with install hints
+3. Exit 0 if all required tools are present, exit 1 if any are missing
+4. Detect platform and give platform-specific install commands
+
+Example output:
+```
+Checking prerequisites for despicable-agents...
+  [ok] git 2.39.0
+  [ok] bash 5.2.15
+  [!!] jq not found
+       Install: brew install jq (macOS) | apt install jq (Ubuntu/Debian)
+  [ok] gh 2.40.0 (optional)
+
+1 required tool missing. Install it and re-run ./install.sh
+```
+
+**(c) How to communicate "macOS/Linux only" without sounding immature:**
+
+Do NOT say "macOS/Linux only" -- that frames a negative. Instead, state what IS supported and what the status is for other platforms. Use the same pattern as Claude Code's own docs.
+
+Recommended language for the README:
+
+> **Tested on macOS and Linux.** Windows support via WSL works but is not tested in CI. Native Windows (Git Bash) has known limitations with symlinks -- see [Platform Notes](#platform-notes) for workarounds.
+
+This is honest, specific, and gives Windows users an immediate path (WSL) rather than a dead end. The phrase "not tested in CI" signals this is a maturity/resource issue, not an architectural one.
+
+For a dedicated section lower in the README:
+
+> ### Platform Notes
+>
+> despicable-agents uses symlinks for deployment (`install.sh` creates symlinks to `~/.claude/agents/`). This works natively on macOS and Linux.
+>
+> **Windows users** have two options:
+> 1. **WSL (recommended):** Run `./install.sh` inside WSL. Claude Code supports WSL natively.
+> 2. **Git Bash:** Enable Developer Mode in Windows Settings, then run with `MSYS=winsymlinks:nativestrict ./install.sh`. Symlinks require elevated permissions or Developer Mode on Windows.
+>
+> The commit workflow hooks require **bash 4+** and **jq**. macOS ships with bash 3.2 -- install a newer version via `brew install bash`. See [Prerequisites](#prerequisites) for details.
+
+**(d) CLI tool documentation with cross-platform install instructions:**
+
+Use a single table with one row per tool and platform-specific install commands. This is the most scannable format for developers who need to install one missing tool.
+
+```markdown
+## Required Tools
+
+| Tool | Version | macOS | Ubuntu/Debian | Windows |
+|------|---------|-------|---------------|---------|
+| git | 2.20+ | `xcode-select --install` or `brew install git` | `sudo apt install git` | [git-scm.com](https://git-scm.com/downloads/win) (required for Claude Code) |
+| jq | 1.6+ | `brew install jq` | `sudo apt install jq` | `winget install jqlang.jq` |
+| bash | 4.0+ | `brew install bash` | Pre-installed | Included with Git for Windows |
+| gh | 2.0+ | `brew install gh` | See [cli.github.com](https://cli.github.com) | `winget install GitHub.cli` |
+
+**Note:** `git` and `bash 4+` are required for core functionality. `jq` is required for commit workflow hooks. `gh` is optional (used for PR creation suggestions).
+```
+
+**(e) The "paste this list and ask Claude Code to install them" approach:**
+
+This is viable and clever. Claude Code can run shell commands, so the user pastes a block and Claude Code handles the platform detection and package manager selection. Format it as a single copy-pasteable prompt, not individual commands.
+
+Recommended format in the README:
+
+> ### Quick Setup
+>
+> After cloning, paste this into Claude Code and it will install any missing prerequisites:
+>
+> ```
+> Check if these tools are installed and install any that are missing:
+> - git 2.20+
+> - jq 1.6+
+> - bash 4+ (on macOS, the system bash is 3.2 -- install via brew)
+> - gh CLI (optional, for PR creation)
+> Then run ./install.sh
+> ```
+
+This works because:
+- Claude Code detects the platform automatically
+- It knows the right package manager (brew, apt, winget, etc.)
+- It can verify versions and only install what is actually missing
+- It runs `./install.sh` at the end, closing the loop
+
+The key design choice: give it as a plain-English prompt, not a bash script. Claude Code understands natural language better than a script that tries to handle every platform. This also means it works on platforms we have not tested -- Claude Code will figure out the right package manager for Fedora, Arch, etc.
+
+### 4. Cross-Platform Stability Path
+
+For achieving actual cross-platform stability, there are three tiers of effort:
+
+**Tier 1 -- Documentation only (low effort, high value):**
+- Add platform notes, prerequisites, and the Claude Code prompt to README
+- Add `./install.sh check` command
+- Document WSL as the recommended Windows path
+- This is the right first step and may be sufficient for months
+
+**Tier 2 -- Script hardening (moderate effort):**
+- Add bash version check at top of hook scripts (degrade gracefully on bash 3.2)
+- Add `jq` existence check in hook scripts (already fail-safe, but could warn)
+- Make `install.sh` detect platform and warn about symlink issues on Windows
+- Add `--copy` flag to `install.sh` for Windows users who cannot use symlinks (copies instead of symlinks, with a warning that live-editing will not work)
+
+**Tier 3 -- True cross-platform (high effort, questionable value):**
+- Rewrite `install.sh` to detect Windows and use `mklink` or junction points
+- Add a `install.ps1` PowerShell equivalent
+- CI matrix testing on macOS, Ubuntu, Windows
+- This is YAGNI unless Windows usage is significant
+
+My recommendation: **Do Tier 1 now. Defer Tier 2 and Tier 3** until there is evidence of Windows users hitting issues. The project's own engineering philosophy (YAGNI, lean and mean) supports this.
+
+
+## Proposed Tasks
+
+### Task 1: Add Prerequisites and Platform Notes to README
+
+**What:** Add three new sections to `README.md`: Prerequisites checklist, Platform Notes, and Quick Setup (Claude Code prompt).
+
+**Deliverables:**
+- Updated `README.md` with Prerequisites section (tool checklist with versions)
+- Platform Notes section with Windows guidance (WSL recommended, Git Bash workaround)
+- Quick Setup section with copy-pasteable Claude Code prompt for dependency installation
+- Updated "Current Limitations" to include platform note
+
+**Dependencies:** None. Can be done first.
+
+### Task 2: Add `./install.sh check` Command
+
+**What:** Add a `check` subcommand to `install.sh` that verifies prerequisites (git, jq, bash version, gh) with platform-specific install hints and color-coded pass/fail output.
+
+**Deliverables:**
+- Updated `install.sh` with `check` subcommand
+- Platform detection (macOS/Linux/Windows-Git-Bash)
+- Per-tool version check with clear pass/fail output
+- Platform-specific install commands in failure messages
+- Exit code 0 (all present) or 1 (missing tools)
+
+**Dependencies:** None. Can be done in parallel with Task 1.
+
+### Task 3: Update `docs/deployment.md` Prerequisites
+
+**What:** Expand the existing Prerequisites section in deployment.md (currently just mentions jq and chmod) to include the full tool inventory with version requirements.
+
+**Deliverables:**
+- Updated deployment.md with complete prerequisites table
+- Cross-reference to README Quick Setup
+- Note about `./install.sh check` command
+
+**Dependencies:** Task 1 (for consistent language), Task 2 (for check command reference).
+
+
+## Risks and Concerns
+
+1. **Windows symlink model is fundamentally incompatible.** The project's core value proposition (edit agent files, changes are immediately live) depends on symlinks. A `--copy` fallback would work for install but lose the live-editing benefit. This is not a bug to fix -- it is an architectural constraint. Document it honestly rather than promising Windows support that delivers a degraded experience.
+
+2. **bash 3.2 on stock macOS is a silent failure.** The hook scripts use `local -A` (associative arrays) which silently fail or produce unexpected behavior on bash 3.2. Since hooks trap errors and exit 0, users will never see an error -- they will just not get commit checkpoints. This is confusing. At minimum, the hooks should check bash version and warn on stderr.
+
+3. **jq is a hidden dependency.** It is not mentioned in the README or install instructions, only in `docs/deployment.md` under "Prerequisites" in the Hook Deployment section. A user who clones and runs `./install.sh` will succeed, but their hooks will silently fail. The `./install.sh check` command would surface this.
+
+4. **The "Claude Code prompt" approach depends on Claude Code being available.** This is a reasonable assumption for this project (Claude Code is a prerequisite), but the prompt should be positioned as a convenience, not the only path. Keep the manual install table as the primary reference.
+
+5. **`gh` CLI is mentioned in commit-point-check.sh output but is truly optional.** The hook suggests `gh pr create` commands but also provides a fallback (`git push`). This should be clearly labeled "optional" in prerequisites to avoid users installing tools they do not need.
+
+
+## Additional Agents Needed
+
+**software-docs-minion** should be involved for the actual README and deployment.md prose. The devx-minion contribution above provides the information architecture (what sections, what format, what content) and ready-to-use prompts, but the docs specialist should review the final language for consistency with existing documentation tone and structure.
+
+**iac-minion** may have useful input on the `./install.sh check` implementation, particularly around platform detection patterns and cross-platform shell scripting conventions. However, this is a simple enough script that it could be handled without specialist input.
+
+No other agents are needed beyond those already in the planning team.
+
+
+## Appendix: Ready-to-Use Prompts
+
+The user requested prompts for the execution phase. Here they are.
+
+### Prompt A: Platform Disclaimer for README
+
+Insert after the current "Install" section:
+
+```markdown
+### Platform Support
+
+**Tested on macOS and Linux.** Windows support via WSL works but is not tested in CI. Native Windows (Git Bash) has known limitations with symlinks -- see [Platform Notes](#platform-notes) for workarounds.
+
+### Prerequisites
+
+The install script (`./install.sh`) requires only `git`. The commit workflow hooks require additional tools:
+
+| Tool | Version | Required For | Install |
+|------|---------|--------------|---------|
+| git | 2.20+ | Core (install, hooks) | Pre-installed on macOS (`xcode-select --install`). `sudo apt install git` on Ubuntu. |
+| bash | 4.0+ | Commit hooks | macOS ships 3.2 -- run `brew install bash`. Pre-installed on Linux. |
+| jq | 1.6+ | Commit hooks | `brew install jq` (macOS). `sudo apt install jq` (Ubuntu/Debian). |
+| gh | 2.0+ | PR suggestions (optional) | `brew install gh` (macOS). See [cli.github.com](https://cli.github.com). |
+
+Run `./install.sh check` to verify prerequisites.
+```
+
+Add before "Contributing":
+
+```markdown
+### Platform Notes
+
+despicable-agents uses symlinks for deployment. `install.sh` creates symlinks from the repository to `~/.claude/agents/`, so edits to agent files are immediately live. This works natively on macOS and Linux.
+
+**Windows users** have two options:
+1. **WSL (recommended):** Clone the repo inside WSL and run `./install.sh`. Claude Code supports WSL natively.
+2. **Git Bash:** Enable Developer Mode in Windows Settings (Settings > Update & Security > For developers), then run: `MSYS=winsymlinks:nativestrict ./install.sh`. Without Developer Mode, symlink creation requires an elevated (admin) terminal.
+
+The commit workflow hooks (`.claude/hooks/`) require **bash 4+** and **jq**. macOS ships with bash 3.2 -- install a newer version via Homebrew (`brew install bash`).
+```
+
+### Prompt B: Required CLI Tools with "Ask Claude Code" Install
+
+Add to README after Prerequisites:
+
+```markdown
+### Quick Setup
+
+After cloning, paste this into a Claude Code session to install any missing prerequisites and deploy:
+
+> Check if these tools are installed and install any that are missing:
+> - git 2.20+
+> - jq 1.6+
+> - bash 4.0+ (on macOS, system bash is 3.2 -- needs brew install bash)
+> - gh CLI (optional, for PR creation)
+> Then run ./install.sh in this repo to deploy the agents.
+```
+
+### Prompt C: Cross-Platform Stability (for future execution)
+
+```
+Harden install.sh and hook scripts for cross-platform use:
+
+1. Add `./install.sh check` subcommand that:
+   - Detects platform (macOS/Linux/Windows-Git-Bash/WSL)
+   - Checks each required tool: git (2.20+), bash (4.0+), jq (1.6+), gh (2.0+, optional)
+   - Prints color-coded pass/fail per tool
+   - Shows platform-specific install commands for missing tools
+   - Exits 0 if all required present, 1 if any missing
+
+2. Add bash version guard to commit-point-check.sh:
+   - At top of main(), check BASH_VERSINFO[0] >= 4
+   - If bash < 4, write warning to stderr and exit 0 (degrade gracefully)
+   - This prevents silent failures on macOS stock bash
+
+3. Add jq existence check to both hook scripts:
+   - Before first jq call, check `command -v jq`
+   - If missing, write warning to stderr and exit 0
+
+4. In install.sh install_agents(), add Windows detection:
+   - Check if running in MSYS/Git Bash (`[[ "$OSTYPE" == msys* ]]`)
+   - If yes, check for MSYS=winsymlinks:nativestrict
+   - Warn if not set, with instructions to enable Developer Mode
+```

--- a/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase2-iac-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase2-iac-minion-prompt.md
@@ -1,0 +1,61 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise
+to help build a comprehensive plan.
+
+## Project Task
+check if we are fine on all platforms and if not, what it would take to be safe on windows, macOS, linux
+we should think about adding documentation disclaimers that this is mac-only until we have that fixed (if the answer is "not yet")
+also think about documenting all command line tools that are expected to be available
+in the report, include prompts for
+- the docs disclaimer for platform specificity for now
+- documentation on required command line tools and how to install them ("ask claude code to do it for you, just paste the list")
+- achieving cross-platform stability
+
+## Your Planning Question
+Given the three shell scripts (`install.sh`, `track-file-changes.sh`, `commit-point-check.sh`) and the bash snippets embedded in SKILL.md files, what is the minimal set of changes needed to support macOS (including stock bash 3.2), Linux, and Windows (Git Bash / WSL)? Specifically:
+(a) Can we avoid bash 4+ features in hooks to support stock macOS?
+(b) What is the Windows story -- do we target Git Bash, WSL, or PowerShell?
+(c) Should we use `$TMPDIR` consistently instead of hardcoded `/tmp/`?
+(d) What is the cross-platform equivalent for symlinks on Windows -- junctions, mklink, or copy-based deployment?
+(e) Are there POSIX-only alternatives for the bash-specific features used?
+
+## Context
+Read these files from the working directory /Users/ben/github/benpeter/despicable-agents:
+- `install.sh`
+- `.claude/hooks/track-file-changes.sh`
+- `.claude/hooks/commit-point-check.sh`
+- `.claude/settings.json`
+- `skills/nefario/SKILL.md` (especially bash snippets for scratch dirs and status files)
+- `the-plan.md` (deployment section, search for "realpath")
+- `.claude/hooks/sensitive-patterns.txt`
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed
+into a team recommendation, not an execution plan. Focus on analysis,
+trade-offs, and recommendations rather than implementation tasks.
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. If you believe additional specialists should be involved that
+   aren't already part of the planning, say so and explain why
+5. Return your contribution in this format:
+
+## Domain Plan Contribution: iac-minion
+
+### Recommendations
+<your expert recommendations for this aspect of the task>
+
+### Proposed Tasks
+<specific tasks that should be in the execution plan>
+For each task: what to do, deliverables, dependencies
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why>
+(or "None" if the current team is sufficient)
+
+6. Write your complete contribution to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-W2FlrM/cross-platform-compatibility-check/phase2-iac-minion.md`

--- a/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase2-iac-minion.md
+++ b/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase2-iac-minion.md
@@ -1,0 +1,204 @@
+# Domain Plan Contribution: iac-minion
+
+## Recommendations
+
+### (a) Bash 3.2 Compatibility -- Stock macOS Is Broken Today
+
+**`commit-point-check.sh` requires bash 4+ and will fail on stock macOS `/bin/bash` (3.2.57).**
+
+The following bash 4+ features are used in `commit-point-check.sh`:
+
+| Feature | Lines | Bash version required | Impact |
+|---------|-------|-----------------------|--------|
+| `local -A seen_paths` (associative array) | 170 | 4.0+ | **Fatal**: syntax error, script crashes |
+| `local -a ledger_files=()` (array init in local) | 163-165 | 4.0+ (3.2 allows `local -a x` but not `local -a x=()`) | **Fatal**: syntax error |
+| `${seen_paths[$filepath]+x}` (associative array subscript) | 173 | 4.0+ | **Fatal** |
+| `seen_paths[$filepath]=1` (associative array assignment) | 174 | 4.0+ | **Fatal** |
+
+`install.sh` and `track-file-changes.sh` are clean -- they use only bash 3.2-compatible constructs.
+
+**However**, this may not matter in practice: Claude Code bundles its own shell environment and likely invokes hooks with a modern bash (the user's current macOS has bash 5.3.9 installed via Homebrew). The question is whether Claude Code uses `/bin/bash` or the first `bash` on `$PATH` when resolving `#!/usr/bin/env bash`. On macOS with Homebrew, `env bash` typically resolves to the Homebrew bash 5.x. On a fresh macOS without Homebrew, it would hit `/bin/bash` 3.2 and crash.
+
+**Recommendation**: Fix the bash 4+ dependency regardless. The fix is small and eliminates a class of platform bugs. POSIX-compatible alternatives exist for every construct used (see section e below).
+
+### (b) Windows Story -- Target Git Bash (MSYS2), Not PowerShell
+
+Windows has three possible bash environments:
+
+| Environment | Availability | Symlink support | `/tmp/` | `jq` availability | `mktemp` | `chmod` |
+|-------------|-------------|----------------|---------|-------------------|----------|---------|
+| **Git Bash (MSYS2)** | Ships with Git for Windows (near-universal for devs) | No real symlinks; `ln -s` creates copies | Mapped to `$TMPDIR` or `C:\Users\...\AppData\Local\Temp` | Must install separately | Available | No-op on NTFS (silently succeeds) |
+| **WSL** | Optional install, requires admin | Full POSIX symlinks (within WSL filesystem) | Standard `/tmp/` | `apt install jq` | Available | Works |
+| **PowerShell** | Built-in | `New-Item -ItemType SymbolicLink` (requires admin or dev mode) | No `/tmp/` | Must install separately | N/A | N/A |
+
+**Recommendation**: Target **Git Bash** as the primary Windows environment. Rationale:
+- Claude Code itself likely requires Git, so Git Bash is available by definition.
+- WSL is a heavier dependency (requires Hyper-V/WSL2 install, separate filesystem).
+- PowerShell would require rewriting all scripts and is fundamentally a different shell.
+
+**Key Git Bash limitations that affect us**:
+1. **Symlinks are fake**: `ln -s` in Git Bash creates a file copy, not a symlink. Updates to the source file are NOT reflected at the target. This breaks the entire `install.sh` paradigm (the docs say "edits are immediately live").
+2. **`chmod` is a no-op**: `chmod 700` succeeds silently but does nothing meaningful on NTFS. This weakens the scratch directory security model.
+3. **`/tmp/` path mapping**: Git Bash maps `/tmp` to a Windows temp directory, but the path differs from what a native Windows process would see. If Claude Code invokes hooks through a non-MSYS process, `/tmp/` paths in the ledger may not resolve.
+4. **`jq` not bundled**: Git for Windows does not include `jq`. Both hooks require it.
+
+### (c) `$TMPDIR` Consistency -- Mixed Usage Today
+
+**Current state**:
+- `SKILL.md` scratch directory: Uses `${TMPDIR:-/tmp}` -- **correct**.
+- `SKILL.md` status files: Hardcodes `/tmp/nefario-status-$SID` -- **inconsistent**.
+- `SKILL.md` session-id: Hardcodes `/tmp/claude-session-id` -- **inconsistent**.
+- `SKILL.md` PR body temp: Hardcodes `/tmp/pr-body-$$` -- **inconsistent**.
+- `track-file-changes.sh`: Hardcodes `/tmp/claude-change-ledger-...` -- **inconsistent**.
+- `commit-point-check.sh`: Hardcodes `/tmp/claude-change-ledger-...`, `/tmp/claude-commit-defer-...`, `/tmp/claude-commit-declined-...`, and checks `/tmp/nefario-status-...` -- **inconsistent**.
+
+**Recommendation**: Standardize all temp file references to `${TMPDIR:-/tmp}`. This is the single most impactful cross-platform fix:
+- On macOS, `$TMPDIR` points to `/var/folders/xx/.../T/` (per-user, already set by the OS).
+- On Linux, `$TMPDIR` is typically unset, so `/tmp` is the fallback (correct).
+- On Git Bash/Windows, `$TMPDIR` resolves to the Windows temp directory, which is accessible from both MSYS and native processes.
+
+**Critical coupling**: The hooks and SKILL.md must agree on the temp file location. If `track-file-changes.sh` writes to `/tmp/claude-change-ledger-X` but `commit-point-check.sh` looks at `${TMPDIR:-/tmp}/claude-change-ledger-X`, they will diverge on macOS where `TMPDIR` is not `/tmp`. Today this works by accident because both hardcode `/tmp/` -- but the scratch directory uses `$TMPDIR` and already lives in a different directory on macOS. Standardize all to `${TMPDIR:-/tmp}` for consistency.
+
+### (d) Symlinks on Windows -- The Core Deployment Problem
+
+This is the **hardest cross-platform issue**. Options:
+
+| Strategy | Pros | Cons |
+|----------|------|------|
+| **Junction points** (`mklink /J`) | Works without admin; directory-level only; real filesystem link | Git Bash can't create them natively; requires `cmd /c mklink /J`; files only work with hardlinks |
+| **`mklink /D`** (directory symlink) | True symlink | Requires admin privileges or Developer Mode enabled |
+| **Copy-based deployment** | Works everywhere; no privilege requirements | Edits are NOT live; must re-run install after every change |
+| **Git worktree/submodule** | Avoids symlinks entirely | Completely different architecture; complex |
+
+**Recommendation**: Implement a **copy-based fallback** for Windows in `install.sh`. Detect the platform, and if symlinks are not supported (or fail), fall back to copying files. Add a warning that changes require re-running `./install.sh`.
+
+```sh
+# Platform detection
+create_link() {
+    local source="$1" target="$2"
+    if ln -sf "$source" "$target" 2>/dev/null; then
+        return 0
+    fi
+    # Fallback: copy
+    cp -r "$source" "$target"
+    USED_COPY_FALLBACK=true
+}
+```
+
+At the end, if `USED_COPY_FALLBACK` is set, print a warning:
+> "Symlinks not available. Files were copied. Re-run install.sh after changes."
+
+### (e) POSIX Alternatives for Bash-Specific Features
+
+**Associative array (`local -A seen_paths`) in `commit-point-check.sh`**:
+Replace with a temporary file-based dedup (the ledger is already a file):
+```sh
+# Instead of associative array dedup, use sort -u on the ledger
+ledger_files=$(sort -u "$ledger")
+```
+Or use `awk '!seen[$0]++'` for streaming dedup preserving order.
+
+**Array variables (`local -a`)**: Replace with newline-delimited strings and iterate with `while read`. This is standard POSIX sh. The loop logic at lines 184-217 can be restructured to process files one-at-a-time without accumulating arrays, writing filtered results to temp files.
+
+**`[[ ... ]]` conditionals**: These are bash-specific but available in bash 3.2. If targeting pure POSIX sh (`#!/bin/sh`), replace with `[ ... ]` and `case` statements. However, since all scripts use `#!/usr/bin/env bash`, `[[ ]]` is fine as long as we stay on bash (any version).
+
+**`echo -e` in `install.sh`**: Non-portable (some systems' `echo` ignores `-e`). Replace with `printf` for guaranteed escape sequence handling. This is a minor issue but a free fix.
+
+**`${BASH_SOURCE[0]}`**: Bash-specific, not available in POSIX sh. If we ever target `/bin/sh`, replace with `$0` (works for directly-executed scripts, not sourced ones). For current use case (direct execution), this is fine.
+
+**`readlink` in `install.sh`**: macOS `readlink` does not support `-f` (canonicalize). The current code uses bare `readlink` (without `-f`), which works cross-platform for reading one level of symlink. The `the-plan.md` deployment section uses `realpath`, which IS available on recent macOS but NOT on older macOS or minimal Linux (e.g., Alpine without coreutils). The `install.sh` avoids `realpath` and uses `cd ... && pwd` instead -- this is the correct portable pattern.
+
+### External Tool Dependencies
+
+Complete inventory of external tools required by the shell scripts and hooks:
+
+| Tool | Used by | Availability | Windows (Git Bash) | Notes |
+|------|---------|-------------|-------------------|-------|
+| `bash` | All scripts | macOS (3.2 stock, 5.x Homebrew), Linux | Git Bash bundles bash 5.x | Stock macOS 3.2 breaks commit hook |
+| `jq` | Both hooks | Not pre-installed anywhere | Not in Git Bash | **Must be explicitly installed** |
+| `git` | commit-point-check.sh | Universal for devs | Git Bash bundles it | Core dependency |
+| `gh` | SKILL.md PR workflows | Optional (GitHub CLI) | Available via installer | Only needed for PR creation |
+| `grep` | track-file-changes.sh | POSIX standard | Git Bash bundles it | Using `-qFx` (POSIX flags) |
+| `awk` | commit-point-check.sh | POSIX standard | Git Bash bundles it | Simple usage, portable |
+| `mktemp` | SKILL.md scratch dir | macOS/Linux standard | Git Bash bundles it | `-d` flag is POSIX |
+| `sort` | (proposed dedup) | POSIX standard | Git Bash bundles it | |
+| `basename`/`dirname` | All scripts | POSIX standard | Git Bash bundles it | |
+| `readlink` | install.sh (uninstall) | macOS/Linux | Git Bash bundles it | Without `-f`, portable |
+| `realpath` | the-plan.md examples | macOS 13+, most Linux | Not in Git Bash by default | **Avoid in scripts; use `cd && pwd`** |
+| `chmod` | SKILL.md scratch dir | POSIX standard | **No-op on Windows** | Security model weakened |
+| `touch` | hooks (ledger, markers) | POSIX standard | Git Bash bundles it | |
+| `printf` | (proposed echo -e replacement) | POSIX standard | Git Bash bundles it | |
+
+## Proposed Tasks
+
+### Task 1: Fix bash 4+ dependencies in commit-point-check.sh
+**What**: Rewrite `commit-point-check.sh` to avoid associative arrays and bash 4+ array initialization. Replace `local -A seen_paths` with file-based dedup (pipe ledger through `awk '!seen[$0]++'`). Replace `local -a var=()` with `local var=""` and newline-delimited processing.
+**Deliverables**: Updated `commit-point-check.sh` that passes `shellcheck` and works on bash 3.2.
+**Dependencies**: None. Can be done independently.
+
+### Task 2: Standardize temp file paths to use `${TMPDIR:-/tmp}`
+**What**: Replace all hardcoded `/tmp/` references with `${TMPDIR:-/tmp}` in:
+- `.claude/hooks/track-file-changes.sh` (ledger path)
+- `.claude/hooks/commit-point-check.sh` (ledger, defer marker, declined marker, nefario status check)
+- `skills/nefario/SKILL.md` (status files, session-id, PR body temp)
+- `docs/commit-workflow.md` (example snippets)
+
+Define a single `TEMP_BASE="${TMPDIR:-/tmp}"` variable at the top of each script and reference it throughout.
+**Deliverables**: Updated scripts and SKILL.md. Grep for bare `/tmp/` to verify none remain.
+**Dependencies**: None. Can be done independently, but test that hooks still interoperate (they share file paths).
+
+### Task 3: Add copy-based fallback to install.sh for Windows
+**What**: Add platform detection to `install.sh`. If `ln -sf` fails (or if running on Windows/MSYS), fall back to file/directory copying. Print a clear warning about the copy-based limitation.
+Also fix `echo -e` to use `printf` for portability.
+**Deliverables**: Updated `install.sh` with `create_link()` helper, platform detection, and copy fallback.
+**Dependencies**: None.
+
+### Task 4: Document platform compatibility and prerequisites
+**What**: Create a `docs/platform-support.md` document covering:
+- Platform support matrix (macOS: full, Linux: full, Windows: partial with caveats)
+- Required CLI tools with installation instructions (or "ask Claude Code to install them")
+- Known Windows limitations (symlinks become copies, chmod no-op, jq manual install)
+- Disclaimer for README about current macOS-primary development
+
+Also add a short disclaimer section to the project README.
+**Deliverables**: `docs/platform-support.md`, updated README section.
+**Dependencies**: Tasks 1-3 inform what the documentation says (do those first or in parallel and update docs at the end).
+
+### Task 5: Add `shellcheck` CI validation
+**What**: Add a simple CI check (GitHub Actions or local script) that runs `shellcheck` against all `.sh` files. This prevents future regressions toward bash 4+ features or non-portable constructs.
+**Deliverables**: `.github/workflows/shellcheck.yml` or a `check.sh` script. Configure shellcheck to enforce bash 3.2 compatibility (`# shellcheck shell=bash` with appropriate directive for minimum version).
+**Dependencies**: Task 1 must be complete first (current code would fail shellcheck for some issues).
+
+## Risks and Concerns
+
+### Risk 1: Hook path coordination (HIGH)
+The temp file paths in hooks and SKILL.md are tightly coupled. If `track-file-changes.sh` writes the ledger to one path and `commit-point-check.sh` reads from a different path (due to inconsistent `$TMPDIR` usage), the commit checkpoint silently stops working. The fix (Task 2) must update ALL references atomically. A missed reference means a silent failure with no error message.
+
+### Risk 2: Windows symlink story is fundamentally limited (MEDIUM)
+Even with a copy fallback, the Windows developer experience is degraded: edits to `AGENT.md` files are not live until `install.sh` is re-run. This is a significant workflow difference. For Windows users who use WSL, the full Unix experience is available, but documenting both paths (Git Bash with caveats vs WSL with full support) adds complexity.
+
+### Risk 3: `jq` as undocumented hard dependency (HIGH)
+Both hooks silently malfunction if `jq` is not installed. On `track-file-changes.sh`, the `|| echo ""` fallback means file paths are never extracted, so the ledger stays empty and commit checkpoints never fire. This is a silent failure. On `commit-point-check.sh`, the session ID extraction fails, pointing at a nonexistent ledger. Neither hook checks for `jq` availability or produces a helpful error.
+
+**Mitigation**: Add a `jq` presence check at the top of each hook (or a shared preamble). If `jq` is missing, either skip gracefully with a one-time warning or fail with a clear install instruction.
+
+### Risk 4: `chmod 700` security model breaks on Windows (LOW)
+The scratch directory security relies on Unix file permissions. On Windows (Git Bash), `chmod` is a no-op -- the scratch directory is readable by any process running as the same Windows user. This is acceptable for a development tool but should be documented.
+
+### Risk 5: Claude Code's own shell invocation is opaque (MEDIUM)
+We do not fully control how Claude Code invokes hook commands. The `$CLAUDE_PROJECT_DIR` variable in `settings.json` suggests Claude Code performs its own variable expansion. If Claude Code invokes hooks via a non-bash shell on some platforms, the `#!/usr/bin/env bash` shebang might not be honored (e.g., if invoked as `sh script.sh` instead of `./script.sh`). This is speculative but worth noting -- testing on each platform is required.
+
+### Risk 6: `realpath` in `the-plan.md` deployment examples (LOW)
+The `the-plan.md` deployment section uses `realpath` which is not available on all platforms. The `install.sh` script correctly avoids it, but users following the manual deployment docs could hit failures. The manual deployment examples should use `cd ... && pwd` instead.
+
+## Additional Agents Needed
+
+- **devx-minion**: Already involved (confirmed in scratch directory). Essential for evaluating Claude Code's hook invocation behavior across platforms and the developer experience implications of copy-based deployment on Windows.
+
+- **software-docs-minion**: Already involved. Needed for drafting the platform support documentation, README disclaimer, and CLI prerequisites section.
+
+- **security-minion**: Already involved. Should validate that the weakened security model on Windows (no-op `chmod`, copy-based deployment) does not introduce risks beyond acceptable thresholds for a development tool.
+
+- **test-minion** (recommended addition): Should be consulted on how to validate cross-platform behavior. Specifically: can we add a CI matrix that tests `install.sh` and the hooks on macOS, Ubuntu, and Windows (Git Bash) runners? GitHub Actions provides all three. Even a smoke test (`bash -n script.sh` for syntax validation + `shellcheck`) on each platform would catch regressions.
+
+No other specialists needed beyond those already included plus test-minion.

--- a/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase2-security-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase2-security-minion-prompt.md
@@ -1,0 +1,57 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise
+to help build a comprehensive plan.
+
+## Project Task
+check if we are fine on all platforms and if not, what it would take to be safe on windows, macOS, linux
+we should think about adding documentation disclaimers that this is mac-only until we have that fixed (if the answer is "not yet")
+also think about documenting all command line tools that are expected to be available
+in the report, include prompts for
+- the docs disclaimer for platform specificity for now
+- documentation on required command line tools and how to install them ("ask claude code to do it for you, just paste the list")
+- achieving cross-platform stability
+
+## Your Planning Question
+The hook scripts and SKILL.md use `mktemp -d` with `chmod 700` for scratch directories and `/tmp/` for session state files. If we make these cross-platform:
+(a) Are there security implications of using `$TMPDIR` on Windows (less restrictive permissions model)?
+(b) The current `chmod 600`/`chmod 700` calls are security controls -- what replaces them on Windows/NTFS?
+(c) The `sensitive-patterns.txt` fail-closed design -- does it remain safe if `grep` behavior differs across platforms?
+(d) Any concerns with the symlink-to-junction migration path on Windows?
+
+## Context
+Read these files from the working directory /Users/ben/github/benpeter/despicable-agents:
+- `.claude/hooks/commit-point-check.sh` (especially the security-relevant sections: sensitive file filtering, fail-closed pattern, tmp file paths)
+- `.claude/hooks/track-file-changes.sh` (path injection validation)
+- `.claude/hooks/sensitive-patterns.txt`
+- `skills/nefario/SKILL.md` (scratch directory creation section, search for "mktemp" and "chmod")
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed
+into a team recommendation, not an execution plan. Focus on analysis,
+trade-offs, and recommendations rather than implementation tasks.
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. If you believe additional specialists should be involved that
+   aren't already part of the planning, say so and explain why
+5. Return your contribution in this format:
+
+## Domain Plan Contribution: security-minion
+
+### Recommendations
+<your expert recommendations for this aspect of the task>
+
+### Proposed Tasks
+<specific tasks that should be in the execution plan>
+For each task: what to do, deliverables, dependencies
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why>
+(or "None" if the current team is sufficient)
+
+6. Write your complete contribution to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-W2FlrM/cross-platform-compatibility-check/phase2-security-minion.md`

--- a/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase2-security-minion.md
+++ b/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase2-security-minion.md
@@ -1,0 +1,159 @@
+## Domain Plan Contribution: security-minion
+
+### Recommendations
+
+#### (a) Security implications of `$TMPDIR` on Windows
+
+On macOS and Linux, `/tmp` is a shared directory but the kernel enforces per-user file permissions via the sticky bit and POSIX ACLs. On Windows, the situation is materially different:
+
+1. **`$TMPDIR` resolves to per-user temp on Windows.** On Git Bash / MSYS2 / WSL, `$TMPDIR` typically maps to `C:\Users\<user>\AppData\Local\Temp` (or the WSL `/tmp`). This is actually **more secure by default** than the shared `/tmp` on Unix -- the user's temp directory is ACL'd to their own SID. Other non-admin users cannot enumerate or access files there.
+
+2. **However, the security model inversion is the problem.** On Unix, the explicit `chmod 700` on the `mktemp -d` result is the defense against other local users. On Windows (native, not WSL), `chmod` is a no-op or has very limited effect -- NTFS uses ACLs, not POSIX permission bits. The **effective** security depends entirely on the inherited ACLs of the parent temp directory, not on anything the scripts do. This means:
+   - If a user customizes `TEMP`/`TMP` to point at a shared location (e.g., a network drive, `C:\Temp`), the `chmod 700` call silently does nothing, and the scratch directory is world-readable.
+   - Enterprise environments sometimes redirect temp to network shares for roaming profiles -- this is a real-world scenario, not theoretical.
+
+3. **Recommendation: Accept `$TMPDIR` on Windows as the primary path** (it defaults to per-user temp and is the safest general-purpose choice), but add validation that the resolved temp dir is user-owned and not world-accessible. On native Windows via Git Bash, use `icacls` to verify or set ACLs. On WSL, POSIX semantics apply normally.
+
+#### (b) What replaces `chmod 600`/`chmod 700` on Windows/NTFS
+
+Two distinct scenarios:
+
+**WSL (Windows Subsystem for Linux):** Full POSIX permission semantics work as expected. `chmod 700` works correctly. `mktemp -d` works. No changes needed. This is the lowest-friction path for Windows users.
+
+**Git Bash / MSYS2 (native Windows):** `chmod` calls are mapped through the MSYS POSIX-to-Win32 translation layer. Behavior is partial and unreliable:
+- `chmod 700` may set the read-only attribute but does NOT modify NTFS ACLs
+- The file is still accessible to any process running as the same user (which is fine) but potentially to administrators or other users with `SeBackupPrivilege`
+- There is no reliable POSIX permission enforcement
+
+**Replacement strategy for native Windows (Git Bash):**
+
+| Current Unix control | Windows equivalent |
+|---|---|
+| `chmod 700 dir` | `icacls "$dir" /inheritance:r /grant:r "$USERNAME:(OI)(CI)F"` -- removes inherited ACLs, grants full control only to the current user |
+| `chmod 600 file` | `icacls "$file" /inheritance:r /grant:r "$USERNAME:F"` -- same pattern |
+| `mktemp -d` | Git Bash bundles a `mktemp` that works. PowerShell requires `[System.IO.Path]::GetTempFileName()` pattern |
+
+**Recommendation:** Create a platform abstraction function:
+
+```bash
+secure_tmpdir() {
+    local dir
+    dir=$(mktemp -d "${TMPDIR:-/tmp}/nefario-scratch-XXXXXX")
+    if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "mingw"* ]]; then
+        # Native Windows via Git Bash -- use icacls
+        icacls "$(cygpath -w "$dir")" /inheritance:r /grant:r "$USERNAME:(OI)(CI)F" >nul 2>&1
+    else
+        chmod 700 "$dir"
+    fi
+    echo "$dir"
+}
+```
+
+A similar wrapper is needed for `chmod 600` on status files.
+
+#### (c) Fail-closed design and `grep` behavior differences
+
+The `sensitive-patterns.txt` fail-closed design is in `commit-point-check.sh` lines 147-155. There are two separate concerns:
+
+**The fail-closed gate itself is safe across platforms.** It uses `[[ ! -r "$SENSITIVE_PATTERNS_FILE" ]]` -- a bash built-in test, not `grep`. If the patterns file is unreadable, no files are staged. This works identically in bash on all platforms. **No issue here.**
+
+**The `grep` usage in `track-file-changes.sh` line 63** (`grep -qFx`) is the area to scrutinize:
+
+1. **Line ending differences.** On Windows, `grep` in Git Bash handles both LF and CRLF, but `grep -Fx` (fixed-string, exact full-line match) may fail if the ledger file contains CRLF line endings and the comparison string does not (or vice versa). If the ledger accumulates CRLF entries but the new path has LF, deduplication silently fails and the ledger grows with duplicates. This is **not a security vulnerability** -- it's a functionality issue that could cause duplicate staging prompts, but the sensitive file filter still catches everything.
+
+2. **The sensitive file matching in `commit-point-check.sh` lines 72-89** uses bash glob matching (`[[ "$basename" == $pattern ]]`), NOT `grep`. Bash glob matching is consistent across platforms. **This is safe.**
+
+3. **GNU grep vs BSD grep vs Git Bash grep.** The only `grep` call is in `track-file-changes.sh` for deduplication. The flags used (`-q`, `-F`, `-x`) are POSIX-standard and behave identically across implementations. **No behavioral difference concern.**
+
+**Verdict: The fail-closed design remains safe across platforms.** The only risk is CRLF-induced deduplication failure in the ledger, which is a cosmetic issue, not a security issue. Recommend normalizing line endings in the ledger write path as a defensive measure:
+
+```bash
+# In track-file-changes.sh, ensure LF-only writes
+echo "$file_path" | tr -d '\r' >> "$ledger" 2>/dev/null || true
+```
+
+#### (d) Symlink-to-junction migration on Windows
+
+This is the highest-risk area of the four questions. The current system uses symlinks in two contexts:
+
+1. **`install.sh` deployment symlinks** -- `ln -sf` to create `~/.claude/agents/foo.md -> /path/to/repo/foo/AGENT.md` and `~/.claude/skills/nefario -> /path/to/repo/skills/nefario/`
+2. **Claude Code project config** -- `.claude/settings.json` references `$CLAUDE_PROJECT_DIR` which resolves through symlinks
+
+**Windows symlink security concerns:**
+
+| Concern | Detail | Severity |
+|---|---|---|
+| **Privilege requirement** | Creating symlinks on Windows requires `SeCreateSymbolicLinkPrivilege`, which is not granted to standard users by default. Developer Mode enables it, but enterprise group policies often block Developer Mode. | HIGH (adoption barrier) |
+| **Junction semantics differ from symlinks** | Junctions are directory-only, resolve at the filesystem level (not the application level), and do NOT work for files. `install.sh` symlinks individual `.md` files -- junctions cannot replace these. | CRITICAL (functional breakage) |
+| **Junction traversal attacks** | Junctions on Windows can be created by unprivileged users (unlike symlinks) and resolve transparently. A malicious local process could replace a junction target to redirect agent loading to an attacker-controlled path. This is the Windows equivalent of symlink attacks in `/tmp`. | HIGH (local privilege escalation vector) |
+| **NTFS reparse points and security software** | Some antivirus/EDR solutions flag junction/symlink creation as suspicious behavior. This could cause installation failures in enterprise environments. | MEDIUM |
+
+**Recommendation: Do NOT use junctions as a symlink replacement.** Instead:
+
+1. **For file symlinks (`agents/*.md`):** Use file copy with a sync/update mechanism. Symlinks to individual files cannot be replaced by junctions (junctions are directory-only). The alternative is `mklink` which requires elevated permissions, or file copy with a version-check wrapper.
+
+2. **For directory symlinks (`skills/nefario`):** Junctions work here but introduce the junction traversal risk above. Prefer `mklink /D` (directory symlink) with Developer Mode, or copy-on-install with a freshness check.
+
+3. **For WSL users:** Symlinks work natively. No migration needed.
+
+4. **Validate symlink/junction targets at load time.** Before reading an agent file through a symlink, verify the target path is within the expected repository directory. This prevents junction hijacking:
+
+```bash
+validate_symlink_target() {
+    local link="$1"
+    local expected_prefix="$2"
+    local target
+    target=$(readlink -f "$link" 2>/dev/null)
+    if [[ "$target" != "$expected_prefix"* ]]; then
+        echo "ERROR: Symlink target outside expected directory: $target" >&2
+        return 1
+    fi
+}
+```
+
+The `install.sh` uninstall function already does target validation (lines 117-122), which is good practice. Extend this to the install path as well.
+
+### Proposed Tasks
+
+**Task 1: Create platform-aware secure temp directory abstraction**
+- What: Write a shared shell function library (e.g., `.claude/hooks/lib/platform.sh`) providing `secure_tmpdir()`, `secure_chmod_600()`, and `secure_chmod_700()` that use NTFS ACLs on native Windows and POSIX permissions elsewhere.
+- Deliverables: `platform.sh` library, updated `SKILL.md` scratch directory section, updated hook scripts to source the library.
+- Dependencies: Decision on which Windows environments to support (WSL-only vs. also Git Bash).
+
+**Task 2: Harden ledger file writes against CRLF injection**
+- What: Add `tr -d '\r'` to ledger write path in `track-file-changes.sh`. Add a line-ending normalization step when reading the ledger in `commit-point-check.sh`.
+- Deliverables: Updated hook scripts.
+- Dependencies: None.
+
+**Task 3: Design Windows deployment strategy for install.sh**
+- What: Decide between (a) WSL-only support with native symlinks, (b) Git Bash support with file copy + sync mechanism, or (c) PowerShell install script for native Windows. Document the decision and security trade-offs of each approach.
+- Deliverables: Decision document, updated install.sh or new install.ps1.
+- Dependencies: Platform support scope decision.
+
+**Task 4: Document security model differences per platform**
+- What: Add a "Platform Security Notes" section to documentation covering: temp directory permissions model, symlink/junction behavior, and any security controls that degrade on specific platforms. This is separate from the general "how to install" docs -- it's the security-specific supplement.
+- Deliverables: Documentation section (could be in a platform-support doc or as part of a SECURITY.md).
+- Dependencies: Tasks 1 and 3 (to know what the final design is).
+
+**Task 5: Add platform detection to hook scripts**
+- What: Add `$OSTYPE` detection at the top of `commit-point-check.sh` and `track-file-changes.sh` to set platform-specific behavior flags. Ensure the scripts exit cleanly (not crash) on unsupported platforms.
+- Deliverables: Updated hook scripts with platform detection.
+- Dependencies: Task 1 (shared library).
+
+### Risks and Concerns
+
+1. **Silent security degradation on Windows.** The most dangerous outcome is that the scripts appear to work on Windows but `chmod` calls are no-ops, leaving temp files and scratch directories with inherited (potentially permissive) ACLs. Users would have no visible indication that their session state files are less protected than on macOS/Linux. This is a **fail-open** condition -- the opposite of the project's stated design philosophy.
+
+2. **Enterprise Windows environments block symlinks.** Group Policy regularly disables `SeCreateSymbolicLinkPrivilege` even with Developer Mode. An install script that relies on `ln -s` will fail silently or noisily, depending on the Git Bash version. This is an adoption barrier, not a security risk per se, but it could push users toward insecure workarounds (running as admin, disabling security policies).
+
+3. **Session ID in temp file paths.** The current pattern `/tmp/claude-change-ledger-${session_id}.txt` embeds the session ID in a predictable path. On macOS/Linux with `/tmp` sticky bit, this is safe -- other users can see the filename but not read the contents (assuming `chmod 600`). On native Windows without proper ACLs, other local users could read ledger contents (file paths being edited), which leaks information about what the user is working on. Low severity but real.
+
+4. **The `$CLAUDE_PROJECT_DIR` variable in settings.json hook commands.** This is resolved by Claude Code itself. If Claude Code does not properly quote or escape this on Windows paths containing spaces (e.g., `C:\Users\John Doe\projects\...`), the hook command will break. The current quoting (`"$CLAUDE_PROJECT_DIR"`) is correct for bash, but if Claude Code on Windows uses cmd.exe or PowerShell to invoke hooks, the quoting semantics differ entirely. This needs investigation -- it's a Claude Code platform behavior question, not something the project controls.
+
+5. **`grep` and `jq` availability.** The hooks depend on `jq` and `grep`. On macOS, `jq` is not installed by default (requires Homebrew). On Windows Git Bash, `jq` is not bundled. On Linux, it varies by distribution. If `jq` is missing, `json_field` silently returns empty strings, causing the hooks to proceed with default/empty values. The `jq` absence does not create a security hole (the fail-closed pattern catches the important case), but it does cause the hooks to malfunction silently. Recommend adding a dependency check at hook entry.
+
+### Additional Agents Needed
+
+- **devx-minion**: Should own the platform abstraction layer design and the install.sh cross-platform strategy. The security decisions (what ACLs to set, how to validate targets) should come from security-minion, but the implementation ergonomics and developer experience are devx-minion's domain.
+- **iac-minion**: If a PowerShell install script (`install.ps1`) is needed for native Windows support, iac-minion should write it. Security-minion should review it.
+- **software-docs-minion**: To draft the platform disclaimers and required-tools documentation. Security-minion provides the security-specific content; docs-minion handles structure, tone, and completeness.

--- a/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase2-software-docs-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase2-software-docs-minion-prompt.md
@@ -1,0 +1,58 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise
+to help build a comprehensive plan.
+
+## Project Task
+check if we are fine on all platforms and if not, what it would take to be safe on windows, macOS, linux
+we should think about adding documentation disclaimers that this is mac-only until we have that fixed (if the answer is "not yet")
+also think about documenting all command line tools that are expected to be available
+in the report, include prompts for
+- the docs disclaimer for platform specificity for now
+- documentation on required command line tools and how to install them ("ask claude code to do it for you, just paste the list")
+- achieving cross-platform stability
+
+## Your Planning Question
+We need to produce three documentation artifacts:
+(a) A platform support disclaimer for README.md and docs (what format, where to place it, how to phrase it for an open-source project that is currently macOS/Linux-only)
+(b) A prerequisites/dependencies page documenting all required CLI tools with per-platform install instructions
+(c) A "cross-platform roadmap" section or tracking issue format for the path to Windows support
+How should these integrate with the existing docs structure (README.md -> docs/architecture.md hub -> sub-docs)? Should the prerequisites doc be standalone or part of deployment.md?
+
+## Context
+Read these files from the working directory /Users/ben/github/benpeter/despicable-agents:
+- `README.md`
+- `docs/architecture.md` (sub-documents table)
+- `docs/deployment.md`
+
+The identified platform issues inventory includes 17 items spanning symlinks, bash version requirements, temp directory handling, chmod, jq dependency, and Windows-specific incompatibilities.
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed
+into a team recommendation, not an execution plan. Focus on analysis,
+trade-offs, and recommendations rather than implementation tasks.
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. If you believe additional specialists should be involved that
+   aren't already part of the planning, say so and explain why
+5. Return your contribution in this format:
+
+## Domain Plan Contribution: software-docs-minion
+
+### Recommendations
+<your expert recommendations for this aspect of the task>
+
+### Proposed Tasks
+<specific tasks that should be in the execution plan>
+For each task: what to do, deliverables, dependencies
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why>
+(or "None" if the current team is sufficient)
+
+6. Write your complete contribution to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-W2FlrM/cross-platform-compatibility-check/phase2-software-docs-minion.md`

--- a/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase2-software-docs-minion.md
+++ b/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase2-software-docs-minion.md
@@ -1,0 +1,319 @@
+## Domain Plan Contribution: software-docs-minion
+
+### Recommendations
+
+#### 1. Platform Support Disclaimer -- Placement and Phrasing
+
+The disclaimer belongs in two locations:
+
+**README.md** -- Add a "Platform Support" callout immediately after the "Install" heading, before the code block. This is where developers hit the first platform-dependent instruction (`./install.sh`). Use a simple bold-text callout, not a badge. Badges communicate status at a glance but bury detail; a callout communicates "stop and read this before you proceed." Phrasing should be honest, specific about what breaks, and link to the tracking issue or roadmap for updates.
+
+**docs/deployment.md** -- Add a "Platform Support" section at the top, after the back-link. This page documents the symlink model and install.sh behavior, which are the two highest-impact platform-specific items. The disclaimer here can be more technical (specific incompatibilities rather than just "not supported").
+
+Do NOT add disclaimers to every sub-document. Two locations is sufficient -- the entry point (README) and the deployment-specific page. Other docs are architecture/design docs that are platform-agnostic by nature.
+
+**Phrasing guidance for an Apache 2.0 open-source project:**
+- Lead with what works, then state what does not. "Tested on macOS and Linux. Windows is not yet supported."
+- Be specific about the failure mode, not vague. "install.sh relies on POSIX symlinks and Bash 4+ features" is better than "may not work on Windows."
+- Link to a tracking issue so users can follow progress.
+- Avoid "coming soon" -- use "contributions welcome" which is honest and actionable for an open-source project.
+
+#### 2. Prerequisites/Dependencies Page -- Standalone vs. Embedded
+
+**Recommendation: Create a new standalone `docs/prerequisites.md`** and add it to the architecture.md sub-documents table under "User-Facing."
+
+Rationale:
+- The deployment.md page already documents symlink mechanics and install.sh behavior. Mixing CLI tool prerequisites into it creates two concerns in one page.
+- Prerequisites are a Day 1 onboarding concern. They need to be findable without reading about symlink architecture.
+- The README "Install" section should link to it: "For prerequisite tools, see [Prerequisites](docs/prerequisites.md)."
+- The page should be task-oriented: "what do I need" then "how do I get it" then "how do I verify."
+
+**Content structure for prerequisites.md:**
+
+```
+# Prerequisites
+
+## Required
+- Claude Code (link to install docs)
+- Git (version X+)
+- Bash 4.0+ (macOS ships Bash 3.2; upgrade via Homebrew)
+- jq (used by commit workflow hooks)
+
+## Optional
+- gh CLI (GitHub CLI, for PR creation at session wrap-up)
+
+## Per-Platform Install
+
+### macOS
+<commands>
+
+### Linux (Debian/Ubuntu)
+<commands>
+
+### Linux (Fedora/RHEL)
+<commands>
+
+### Windows
+Not yet supported. See [Cross-Platform Roadmap](#cross-platform-roadmap) or tracking issue #XX.
+
+## Verify Your Setup
+<verification commands>
+```
+
+**Important detail**: The page should include a "paste this list to Claude Code and ask it to install what is missing" note. This is a clever onboarding shortcut that fits the project's nature (it IS a Claude Code toolkit).
+
+#### 3. Cross-Platform Roadmap -- Format and Location
+
+**Recommendation: GitHub Issue, not a docs page.** A roadmap in docs/ goes stale the moment work starts. A GitHub issue with a checklist is the living tracking artifact. The README and prerequisites.md link to it.
+
+The issue should contain:
+- A checklist of the 17 identified platform issues, grouped by severity
+- Labels: `platform`, `windows`, `help-wanted`
+- A brief section on the architectural approach (POSIX compatibility layer vs. platform-specific install paths)
+
+If the team later decides to formally support Windows, THAT decision warrants an ADR (e.g., `docs/adr/0001-cross-platform-support-strategy.md`). The ADR would document the chosen approach (e.g., "use PowerShell install script alongside bash" vs. "require WSL" vs. "rewrite install.sh in a cross-platform language"). Until the decision is made, the tracking issue is the right artifact.
+
+#### 4. Integration with Existing Docs Structure
+
+The docs hub (`docs/architecture.md`) has two tables: "User-Facing" and "Contributor / Architecture." The new page fits cleanly:
+
+| Table | Document | Rationale |
+|-------|----------|-----------|
+| User-Facing | `prerequisites.md` | Users need this to get started |
+| Contributor / Architecture | No new page needed | Cross-platform work is tracked in a GitHub issue, not a design doc (yet) |
+
+The README changes are inline edits (disclaimer + link), not new sections.
+
+### Proposed Tasks
+
+#### Task 1: Add platform disclaimer to README.md
+
+**What**: Add a "Platform Support" callout to the Install section of README.md, between the "Install" heading and the code block.
+
+**Deliverable**: Updated README.md with disclaimer text and link to tracking issue.
+
+**Dependencies**: The tracking issue (Task 4) should be created first so the README can link to it.
+
+**Suggested copy** (prompt for execution):
+
+```markdown
+> **Platform support:** Tested on macOS and Linux. Windows is not currently
+> supported -- `install.sh` uses POSIX symlinks and Bash 4+ features that
+> are not available natively on Windows. See [#XX](link) for the
+> cross-platform tracking issue. Contributions welcome.
+```
+
+#### Task 2: Add platform details to docs/deployment.md
+
+**What**: Add a "Platform Support" section near the top of deployment.md with specific technical details about platform dependencies: symlinks (`ln -s`), Bash version (`BASH_SOURCE`, `set -euo pipefail`, associative arrays in hooks), `/tmp` path, `readlink` behavior, `chmod +x`, ANSI color codes, `jq` dependency.
+
+**Deliverable**: Updated docs/deployment.md.
+
+**Dependencies**: None (can proceed in parallel with other tasks).
+
+**Suggested copy** (prompt for execution):
+
+```markdown
+## Platform Support
+
+The deployment model depends on:
+
+| Feature | Used By | macOS | Linux | Windows |
+|---------|---------|-------|-------|---------|
+| POSIX symlinks (`ln -s`, `ln -sf`) | install.sh | Yes | Yes | No (NTFS symlinks require admin) |
+| Bash 4.0+ | Hook scripts (associative arrays) | Requires Homebrew bash | Yes (default) | No (requires WSL or Git Bash) |
+| `readlink` (no flags) | install.sh uninstall | Yes | Yes | No |
+| `jq` | Hook scripts | Install via Homebrew | Install via apt/dnf | Install via Scoop/Chocolatey |
+| `/tmp/` temp directory | Change ledger, status files | Yes | Yes | No (`%TEMP%` on Windows) |
+| `chmod +x` | Hook scripts | Yes | Yes | No-op on NTFS |
+| ANSI escape codes | install.sh output | Yes | Yes | Partial (Windows Terminal yes, cmd.exe no) |
+| `gh` CLI (optional) | PR creation | Install via Homebrew | Install via apt/dnf | Install via Scoop/Chocolatey |
+
+macOS and Linux are fully supported. Windows is not supported. See [Prerequisites](prerequisites.md) for required tools and installation instructions.
+```
+
+#### Task 3: Create docs/prerequisites.md
+
+**What**: Create a new prerequisites page documenting all required and optional CLI tools with per-platform install instructions and a verification section.
+
+**Deliverable**: New file `docs/prerequisites.md`, added to architecture.md User-Facing sub-documents table, linked from README.md Install section.
+
+**Dependencies**: None.
+
+**Suggested content structure** (prompt for execution):
+
+```markdown
+[< Back to Architecture Overview](architecture.md)
+
+# Prerequisites
+
+Tools required to install and use despicable-agents.
+
+## Required
+
+| Tool | Minimum Version | Purpose |
+|------|----------------|---------|
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Latest | AI coding assistant that loads the agents |
+| [Git](https://git-scm.com/) | 2.20+ | Version control, used by hooks and commit workflow |
+| [Bash](https://www.gnu.org/software/bash/) | 4.0+ | install.sh and hook scripts (macOS ships 3.2 -- see below) |
+| [jq](https://jqlang.github.io/jq/) | 1.6+ | JSON parsing in hook scripts |
+
+## Optional
+
+| Tool | Purpose |
+|------|---------|
+| [GitHub CLI (`gh`)](https://cli.github.com/) | PR creation at session wrap-up (graceful degradation if absent) |
+
+## Installation by Platform
+
+### macOS
+
+```bash
+# Bash 4+ (macOS ships Bash 3.2 due to licensing)
+brew install bash
+
+# jq
+brew install jq
+
+# GitHub CLI (optional)
+brew install gh
+```
+
+Note: The Homebrew-installed bash is at `/opt/homebrew/bin/bash` (Apple Silicon)
+or `/usr/local/bin/bash` (Intel). The hook scripts use `#!/usr/bin/env bash`
+which resolves to the first `bash` in `$PATH`. Ensure Homebrew's bin directory
+is before `/bin` in your `$PATH`.
+
+### Linux (Debian / Ubuntu)
+
+```bash
+sudo apt update && sudo apt install -y bash jq
+# Optional:
+sudo apt install -y gh
+```
+
+### Linux (Fedora / RHEL)
+
+```bash
+sudo dnf install -y bash jq
+# Optional:
+sudo dnf install -y gh
+```
+
+### Windows
+
+Not currently supported. See the [cross-platform tracking issue](#XX).
+
+If you are on Windows, you may be able to use WSL (Windows Subsystem for Linux)
+with the Linux instructions above, though this is untested.
+
+## Quick Setup via Claude Code
+
+Already have Claude Code running? Paste the following and ask it to install
+any missing tools:
+
+> I need these CLI tools for despicable-agents: bash 4+, jq, git 2.20+,
+> and optionally gh. Check which are missing and install them.
+
+## Verify Your Setup
+
+```bash
+bash --version   # Should show 4.0+
+git --version    # Should show 2.20+
+jq --version     # Should show 1.6+
+gh --version     # Optional -- should show 2.x+
+```
+```
+
+#### Task 4: Create cross-platform tracking issue on GitHub
+
+**What**: Create a GitHub issue with a checklist of the 17 identified platform issues, grouped by category and severity. Label with `platform`, `windows`, `help-wanted`.
+
+**Deliverable**: GitHub issue with structured checklist. URL linked from README and prerequisites.md.
+
+**Dependencies**: The 17-item inventory from the platform audit.
+
+**Suggested issue body** (prompt for execution):
+
+```markdown
+## Cross-Platform Support
+
+despicable-agents is currently tested on macOS and Linux only.
+This issue tracks the work needed to support Windows.
+
+### Blocking Issues (install.sh will not run)
+
+- [ ] `ln -s` / `ln -sf` -- POSIX symlinks not available natively on Windows
+- [ ] `readlink` -- not available on Windows
+- [ ] `BASH_SOURCE[0]` -- not available outside Bash
+- [ ] `set -euo pipefail` -- Bash-specific
+- [ ] Shebang lines (`#!/usr/bin/env bash`) -- not interpreted on Windows
+
+### Blocking Issues (hooks will not run)
+
+- [ ] Bash 4+ associative arrays (`local -A seen_paths`) in commit-point-check.sh
+- [ ] `jq` dependency -- not pre-installed on Windows
+- [ ] `/tmp/` hardcoded temp directory paths (change ledger, status files, defer markers)
+- [ ] `chmod +x` for hook script permissions -- no-op on NTFS
+- [ ] `grep -qFx` -- flags may differ on Windows grep implementations
+
+### Functional Issues
+
+- [ ] ANSI color escape codes in install.sh output -- not supported in cmd.exe
+- [ ] `$HOME` environment variable -- `%USERPROFILE%` on Windows
+- [ ] Path separators (`/` vs `\`) throughout scripts
+- [ ] `~/.claude/` path expansion -- tilde expansion is shell-specific
+
+### Approach Options
+
+**Option A: Require WSL on Windows**
+Lowest effort. Document WSL as a prerequisite for Windows users.
+Pros: No code changes. Cons: Adds friction for Windows users.
+
+**Option B: Add PowerShell install script**
+Write `install.ps1` alongside `install.sh`. Hooks remain Bash (run in Git Bash).
+Pros: Native install experience. Cons: Two scripts to maintain, hooks still need Bash.
+
+**Option C: Cross-platform scripting**
+Rewrite install.sh and hooks in a cross-platform language (Node.js, Python, or Deno).
+Pros: True cross-platform. Cons: Adds a runtime dependency, more complex.
+
+### Current Status
+
+macOS and Linux are supported. Windows support is not planned for the near term.
+Contributions toward any of the above approaches are welcome.
+```
+
+#### Task 5: Update docs/architecture.md sub-documents table
+
+**What**: Add prerequisites.md to the "User-Facing" sub-documents table.
+
+**Deliverable**: Updated architecture.md.
+
+**Dependencies**: Task 3 (prerequisites.md must exist).
+
+**Row to add:**
+
+```markdown
+| [Prerequisites](prerequisites.md) | Required CLI tools, per-platform installation, setup verification |
+```
+
+### Risks and Concerns
+
+1. **macOS Bash 3.2 is a latent bug today, not just a Windows issue.** The hook scripts use `local -A` (associative arrays) which require Bash 4+. macOS ships Bash 3.2. If a macOS user has not installed Bash via Homebrew, the commit-point-check.sh hook will fail silently (because of the ERR trap in track-file-changes, and the `set -euo pipefail` in commit-point-check). This is a real bug affecting current macOS users who have not upgraded Bash. The prerequisites doc must call this out prominently, and the README disclaimer should mention Bash 4+ specifically.
+
+2. **Documentation drift risk.** The platform compatibility table in deployment.md will drift from reality as fixes land. Mitigation: the GitHub tracking issue is the living artifact; the deployment.md table is a snapshot that should reference the issue for current status.
+
+3. **Overloading the README.** The README is currently clean and focused. The disclaimer must be minimal -- one blockquote, not a section. The detail belongs in prerequisites.md and the tracking issue, not the README.
+
+4. **"Contributions welcome" without contributor guidance.** Saying "contributions welcome" for Windows support without specifying which approach (WSL, PowerShell, cross-platform rewrite) is preferred may lead to wasted effort. The tracking issue should include the approach options so contributors can discuss before implementing.
+
+5. **`/tmp/` hardcoding is fragile even on macOS.** macOS sandboxing and some CI environments use different temp directories. While `mktemp -d` would be more robust, changing the temp path pattern affects both hook scripts and the SKILL.md instructions that reference these paths. This is a code change concern, not a docs concern, but the prerequisites doc should note that `/tmp/` must be writable.
+
+### Additional Agents Needed
+
+- **devx-minion**: The install.sh script and hook scripts are developer tooling. Cross-platform compatibility is a developer experience concern. devx-minion should assess the 17-item inventory and recommend the best approach (WSL requirement vs. PowerShell port vs. cross-platform rewrite). This is a tooling design decision, not a documentation decision.
+
+- **iac-minion**: If the chosen approach involves CI-based validation of cross-platform compatibility (e.g., running install.sh in a Windows CI runner), iac-minion should advise on the CI configuration.
+
+No other additional agents are needed. The documentation tasks outlined above are squarely within software-docs-minion scope.

--- a/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase3-synthesis-prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase3-synthesis-prompt.md
@@ -1,0 +1,68 @@
+MODE: SYNTHESIS
+ADVISORY: true
+
+You are synthesizing specialist planning contributions into a
+team recommendation. This is an advisory-only orchestration --
+no code will be written, no branches created, no PRs opened.
+
+Do NOT produce task prompts, agent assignments, execution order,
+approval gates, or delegation plan structure. Produce an advisory
+report using the advisory output format defined in your AGENT.md.
+
+## Original Task
+check if we are fine on all platforms and if not, what it would take to be safe on windows, macOS, linux
+we should think about adding documentation disclaimers that this is mac-only until we have that fixed (if the answer is "not yet")
+also think about documenting all command line tools that are expected to be available
+in the report, include prompts for
+- the docs disclaimer for platform specificity for now
+- documentation on required command line tools and how to install them ("ask claude code to do it for you, just paste the list")
+- achieving cross-platform stability
+
+## Specialist Contributions
+
+Read the following scratch files for full specialist contributions:
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-W2FlrM/cross-platform-compatibility-check/phase2-iac-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-W2FlrM/cross-platform-compatibility-check/phase2-devx-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-W2FlrM/cross-platform-compatibility-check/phase2-software-docs-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-W2FlrM/cross-platform-compatibility-check/phase2-security-minion.md
+
+## Key consensus across specialists:
+
+### iac-minion (Phase: planning)
+Recommendation: Project is NOT cross-platform safe today. commit-point-check.sh uses bash 4+ features (fatal on stock macOS), all temp paths hardcode /tmp/ (broken on Windows), symlinks don't work on Windows Git Bash, jq is undocumented hard dependency.
+Tasks: 5 -- Fix bash 4+ deps; Standardize temp paths; Copy-based fallback for install.sh; Platform docs; Shellcheck CI
+Risks: Hook path coordination (high); Windows symlinks fundamentally limited; jq undocumented (high); chmod no-op on Windows
+Conflicts: none
+
+### devx-minion (Phase: planning)
+Recommendation: Do Tier 1 (documentation) now, defer Tier 2 (script hardening) and Tier 3 (true cross-platform) per YAGNI. Use flat checklist for prerequisites, add ./install.sh check subcommand, frame as "tested on macOS and Linux" not "macOS/Linux only", provide Claude Code prompt for dependency installation.
+Tasks: 3 -- README prerequisites and platform notes; install.sh check subcommand; deployment.md prerequisites update
+Risks: Windows symlink model fundamentally incompatible; bash 3.2 silent failures; jq hidden dependency
+Conflicts: none
+
+### software-docs-minion (Phase: planning)
+Recommendation: Two disclaimer locations (README + deployment.md), new standalone prerequisites.md, cross-platform roadmap as GitHub issue not docs page. macOS bash 3.2 is latent bug today.
+Tasks: 5 -- README disclaimer; deployment.md platform table; docs/prerequisites.md; GitHub tracking issue; architecture.md table update
+Risks: macOS bash 3.2 latent bug; documentation drift; overloading README
+Conflicts: none
+
+### security-minion (Phase: planning)
+Recommendation: $TMPDIR on Windows per-user temp is more secure by default, but chmod is no-op creating fail-open condition. Fail-closed design in hooks is safe cross-platform. Do NOT use junctions as symlink replacement (directory-only, traversal attack risk). WSL is the safe path.
+Tasks: 5 -- Secure temp directory abstraction; CRLF hardening; Windows deployment strategy; Security model docs; Platform detection in hooks
+Risks: Silent security degradation (chmod no-op = fail-open); Enterprise blocks symlinks; Session ID in predictable paths; jq/grep availability
+Conflicts: none
+
+## Instructions
+1. Review all specialist contributions
+2. Resolve any conflicts between recommendations
+3. Identify consensus and dissent -- preserve minority positions
+4. Produce an advisory report with executive summary, team consensus,
+   dissenting views, supporting evidence, risks, next steps, and
+   conflict resolutions
+5. The user specifically requested the report include ready-to-use prompts for:
+   - docs disclaimer for platform specificity
+   - documentation on required CLI tools with install instructions ("ask Claude Code to do it for you, just paste the list")
+   - achieving cross-platform stability
+   Include these as an appendix section in the advisory synthesis.
+6. Write your complete advisory synthesis to
+   /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-W2FlrM/cross-platform-compatibility-check/phase3-synthesis.md

--- a/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase3-synthesis.md
+++ b/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/phase3-synthesis.md
@@ -1,0 +1,322 @@
+## Advisory Report
+
+**Question**: Is despicable-agents cross-platform safe today, and if not, what would it take to support Windows, macOS, and Linux?
+**Confidence**: HIGH
+**Recommendation**: The project is NOT cross-platform safe today. It works on macOS (with Homebrew bash) and Linux. Stock macOS has a latent bash 3.2 bug. Windows is unsupported. The right next step is documentation (disclaimers + prerequisites), not code changes. Follow YAGNI -- document the current state honestly, defer script hardening until there is user demand.
+
+### Executive Summary
+
+Four specialists audited the codebase (iac-minion, devx-minion, software-docs-minion, security-minion) and reached strong consensus: despicable-agents is a macOS-and-Linux project today, with a latent bug even on stock macOS. Windows support is blocked by fundamental symlink incompatibilities that no small fix can resolve.
+
+The most impactful immediate action is documentation: add a platform disclaimer to the README, document all CLI tool prerequisites, and provide a "paste into Claude Code" prompt for easy setup. Code changes (bash 3.2 compatibility, `$TMPDIR` standardization, Windows copy-based fallback) should be deferred per the project's own YAGNI philosophy -- they solve problems that no users have reported yet.
+
+The confidence is HIGH because all four specialists independently arrived at the same conclusion: document first, harden later, and do not promise Windows support without an architectural decision on the deployment model (symlinks vs. copies vs. WSL-only).
+
+### Team Consensus
+
+1. **The project does NOT work on Windows today.** `install.sh` depends on POSIX symlinks (`ln -sf`) which are not natively available on Windows without Developer Mode or admin privileges. This is a fundamental architectural constraint, not a bug to fix.
+
+2. **Stock macOS has a latent bug.** `commit-point-check.sh` uses bash 4+ features (associative arrays via `local -A`, array initialization via `local -a x=()`). macOS ships bash 3.2 due to GPLv3 licensing. Users without Homebrew bash will experience silent hook failures -- the hooks trap errors and exit 0, so there is no visible error message.
+
+3. **`jq` is an undocumented hard dependency.** Both hook scripts require `jq` for JSON parsing. It is not pre-installed on any platform, not mentioned in the README, and only briefly noted in `docs/deployment.md`. When missing, hooks fail silently (empty string fallback), causing the commit checkpoint system to silently stop working.
+
+4. **Documentation is the right first step.** All specialists agreed: add platform disclaimers, document prerequisites, provide installation guidance. Code changes can wait.
+
+5. **WSL is the recommended Windows path.** When Windows users need to use this project, WSL provides full POSIX compatibility with zero code changes. Git Bash is a degraded experience (symlinks become copies, `chmod` is a no-op, `jq` must be installed separately).
+
+6. **Temp file paths are inconsistently hardcoded.** SKILL.md scratch directory uses `${TMPDIR:-/tmp}` (correct), but hook scripts and status files hardcode `/tmp/` throughout. This works today because all paths hardcode the same thing, but it is fragile and will break cross-platform.
+
+7. **The project should NOT promise Windows support.** All specialists agreed: frame the current state honestly ("tested on macOS and Linux"), provide WSL as a workaround, and track Windows support as a future GitHub issue. Do not say "coming soon" -- say "contributions welcome."
+
+### Dissenting Views
+
+- **Copy-based fallback urgency**: iac-minion recommends implementing a copy-based fallback in `install.sh` for Windows now (detect platform, fall back to `cp -r` if `ln -sf` fails). devx-minion and software-docs-minion recommend deferring this per YAGNI -- document it and wait for user demand. Resolution: **defer per YAGNI.** The project philosophy explicitly favors "don't build it until you need it." No evidence of Windows users hitting this issue exists yet. Document the limitation and track it.
+
+- **Junction points as symlink alternative**: iac-minion listed junction points as an option for directory-level symlinks on Windows. security-minion explicitly recommends AGAINST junctions due to junction traversal attack risk (unprivileged users can create junctions, enabling local privilege escalation by redirecting agent loading to attacker-controlled paths). Resolution: **do not use junctions.** security-minion's analysis is more thorough on this point and the risk is real.
+
+- **Prerequisites page location**: software-docs-minion recommends a standalone `docs/prerequisites.md`. devx-minion recommends embedding prerequisites directly in the README as a checklist. Resolution: **both are correct for different audiences.** The README should contain a concise checklist (scannable), with a link to a more detailed `docs/prerequisites.md` for per-platform install commands. This is additive, not contradictory.
+
+- **`install.sh check` subcommand**: devx-minion strongly recommends adding `./install.sh check` as a prerequisite verification command. iac-minion and software-docs-minion do not mention it. Resolution: **include in the recommendation but as Tier 2 (script hardening), not Tier 1 (documentation).** It is a good developer experience improvement but not urgent for the advisory scope of "document the current state."
+
+- **Secure temp directory abstraction**: security-minion recommends a `secure_tmpdir()` function with NTFS ACL handling via `icacls` for native Windows. Other specialists accept `$TMPDIR` standardization as sufficient. Resolution: **defer the Windows-specific `icacls` abstraction.** If the project adopts WSL as the recommended Windows path (consensus), the NTFS ACL problem does not arise. The `$TMPDIR` standardization is the right fix for macOS/Linux consistency and can be done independently of Windows support.
+
+### Supporting Evidence
+
+#### Infrastructure (iac-minion)
+
+Complete audit of bash compatibility across all shell scripts:
+- `install.sh` and `track-file-changes.sh`: clean, bash 3.2 compatible
+- `commit-point-check.sh`: 4 instances of bash 4+ features (associative arrays, array init), all fatal on bash 3.2
+- External tool inventory: 12 tools used across scripts, with `jq` and `bash 4+` as the only non-standard dependencies
+- Temp path audit: 6+ locations hardcode `/tmp/` instead of using `${TMPDIR:-/tmp}`
+
+The POSIX alternatives for bash 4+ features are straightforward:
+- Associative array dedup -> `awk '!seen[$0]++'` or `sort -u` on temp file
+- Array initialization -> newline-delimited strings with `while read` loops
+- All other constructs (`[[ ]]`, `${BASH_SOURCE[0]}`, `set -euo pipefail`) are bash 3.2 compatible
+
+#### Developer Experience (devx-minion)
+
+Tiered approach to cross-platform stability:
+- **Tier 1 (documentation, do now)**: README platform notes, prerequisites checklist, Claude Code setup prompt, WSL guidance for Windows
+- **Tier 2 (script hardening, defer)**: bash version guard in hooks, `jq` existence check, `install.sh check` subcommand, Windows platform detection with warnings
+- **Tier 3 (true cross-platform, likely YAGNI)**: PowerShell install script, CI matrix testing on all three platforms, junction/mklink support
+
+Key developer experience insight: the "paste into Claude Code" setup prompt is a natural fit for this project. Claude Code detects the platform, knows package managers, and can install missing tools. This sidesteps the entire cross-platform install instruction problem.
+
+#### Documentation (software-docs-minion)
+
+Recommended documentation structure:
+- **README.md**: minimal disclaimer (1 blockquote) + prerequisites checklist + link to details
+- **docs/deployment.md**: platform support table with specific technical dependencies
+- **docs/prerequisites.md** (new): standalone page with per-platform install commands, Claude Code prompt, verification commands
+- **GitHub issue**: cross-platform tracking checklist (17 items) with approach options
+- Do NOT create a roadmap doc (goes stale) -- the GitHub issue is the living artifact
+
+Two-location disclaimer strategy: README (entry point for new users) and deployment.md (entry point for platform-specific details). No disclaimers needed in other docs -- they are architecture/design docs that are platform-agnostic.
+
+#### Security (security-minion)
+
+Key security findings specific to cross-platform:
+- **`chmod` no-op on Windows is a fail-open condition.** The scratch directory security model (`chmod 700`) silently degrades to "inherited ACLs from parent" on NTFS. If the temp directory has permissive inherited ACLs (enterprise network shares, custom TEMP paths), session state files become readable by other users.
+- **Junction traversal is a real attack vector.** Do not use NTFS junctions as a symlink replacement -- unprivileged users can create junctions and redirect agent loading to attacker-controlled paths.
+- **The fail-closed design in sensitive-patterns.txt is safe cross-platform.** It uses bash built-in tests, not `grep`. The pattern matching uses bash globs, not regex. Both work identically across platforms.
+- **CRLF injection in the ledger is cosmetic, not a security issue.** Windows line endings could cause duplicate ledger entries but do not bypass the sensitive file filter.
+- **WSL is the safe path for Windows.** Full POSIX semantics, no permission model degradation, no symlink workarounds.
+
+### Risks and Caveats
+
+1. **Stock macOS bash 3.2 is a live bug, not just a cross-platform concern.** Any macOS user without Homebrew bash has silently broken commit hooks today. This is the only finding that affects the current supported platform (macOS). All other issues are Windows-specific or future concerns.
+
+2. **Claude Code's hook invocation model is opaque.** We do not control how Claude Code resolves `#!/usr/bin/env bash` or expands `$CLAUDE_PROJECT_DIR`. If Claude Code uses a different shell or quoting convention on Windows, hook scripts may break in ways we cannot reproduce. This is a Claude Code platform behavior question that requires testing, not just code analysis.
+
+3. **Enterprise Windows environments may block symlinks entirely.** Group Policy can disable `SeCreateSymbolicLinkPrivilege` even with Developer Mode. This means even the WSL path might be restricted in some corporate environments. There is no mitigation for this -- it is a policy constraint outside the project's control.
+
+4. **The "document and wait" approach has a risk of misleading users.** If the README says "tested on macOS and Linux" without specifics, a Linux user with an unusual setup (Alpine without coreutils, Busybox ash) might assume it works and hit failures. The documentation must be specific about dependencies, not just platform names.
+
+5. **Hook path coupling is fragile.** The temp file paths in `track-file-changes.sh`, `commit-point-check.sh`, and `SKILL.md` must all agree. A partial fix (updating some references but not others) would silently break the commit checkpoint system. Any future `$TMPDIR` standardization must be atomic across all files.
+
+### Next Steps
+
+If the recommendation is adopted, the implementation path has two phases:
+
+**Phase 1 -- Documentation (immediate, low effort)**:
+- Add platform disclaimer to README.md (1 blockquote after "Install" heading)
+- Add prerequisites checklist to README.md (tool table with versions)
+- Add "Quick Setup via Claude Code" prompt to README.md
+- Add platform notes section to README.md (symlink explanation, WSL recommendation)
+- Create `docs/prerequisites.md` with per-platform install commands
+- Add platform support table to `docs/deployment.md`
+- Update `docs/architecture.md` sub-documents table
+- Create GitHub issue for cross-platform tracking (17-item checklist)
+
+**Phase 2 -- Script hardening (defer until demand)**:
+- Fix bash 4+ features in `commit-point-check.sh` (POSIX alternatives)
+- Add bash version guard and `jq` existence check to hook scripts
+- Standardize temp paths to `${TMPDIR:-/tmp}` across all files
+- Add `./install.sh check` subcommand
+- Add CRLF normalization to ledger writes
+- Consider `shellcheck` CI validation
+
+**Phase 3 -- Windows support (defer indefinitely, track in issue)**:
+- Architectural decision: WSL-only vs. copy-based fallback vs. PowerShell script
+- If copy-based: implement `create_link()` fallback in `install.sh`
+- If WSL-only: document and close
+- CI matrix testing on macOS, Ubuntu, Windows
+
+### Conflict Resolutions
+
+1. **Junction points**: iac-minion listed as option, security-minion blocked. Resolved in favor of security-minion -- junction traversal is a real local privilege escalation vector.
+
+2. **Immediacy of code changes**: iac-minion proposed 5 implementation tasks (bash fix, temp paths, copy fallback, docs, shellcheck CI). devx-minion recommended Tier 1 docs only, deferring code. Resolved in favor of devx-minion's tiered approach -- consistent with the project's YAGNI/KISS philosophy from CLAUDE.md.
+
+3. **Prerequisites location**: software-docs-minion wanted standalone `docs/prerequisites.md`, devx-minion wanted inline README checklist. Resolved as complementary -- README gets a concise checklist, `docs/prerequisites.md` gets the detailed per-platform install commands. Both serve different reading contexts.
+
+---
+
+## Appendix: Ready-to-Use Prompts
+
+### Prompt 1: Platform Disclaimer for README
+
+Add to README.md immediately after the "Install" heading and before the existing "Requires Claude Code" line:
+
+```markdown
+> **Platform support:** Tested on macOS and Linux. Windows is not currently
+> supported -- `install.sh` uses POSIX symlinks that are not available natively
+> on Windows. Windows users can try [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)
+> (untested). See [Platform Notes](#platform-notes) for details and
+> [Prerequisites](docs/prerequisites.md) for required tools.
+```
+
+Add a "Platform Notes" section before the "License" section at the bottom of README.md:
+
+```markdown
+## Platform Notes
+
+despicable-agents uses symlinks for deployment. `install.sh` creates symlinks
+from the repository to `~/.claude/agents/` and `~/.claude/skills/`, so edits to
+agent files are immediately live without re-installing. This works natively on
+macOS and Linux.
+
+**Windows users** have two options:
+1. **WSL (recommended):** Clone the repo inside WSL and run `./install.sh`.
+   Claude Code supports WSL.
+2. **Git Bash:** Enable Developer Mode in Windows Settings, then run:
+   `MSYS=winsymlinks:nativestrict ./install.sh`. Without Developer Mode,
+   symlink creation requires an elevated (admin) terminal.
+
+The commit workflow hooks require **bash 4+** and **jq**:
+- macOS ships bash 3.2 -- install a newer version via `brew install bash`
+- jq is not pre-installed on any platform -- see [Prerequisites](docs/prerequisites.md)
+```
+
+### Prompt 2: Required CLI Tools Documentation
+
+Create `docs/prerequisites.md`:
+
+```markdown
+[< Back to Architecture Overview](architecture.md)
+
+# Prerequisites
+
+Tools required to install and use despicable-agents.
+
+## Required
+
+| Tool | Minimum Version | Purpose |
+|------|----------------|---------|
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Latest | AI coding assistant that loads the agents |
+| [Git](https://git-scm.com/) | 2.20+ | Version control, used by hooks and install script |
+| [Bash](https://www.gnu.org/software/bash/) | 4.0+ | Hook scripts use bash 4+ features (associative arrays) |
+| [jq](https://jqlang.github.io/jq/) | 1.6+ | JSON parsing in commit workflow hooks |
+
+## Optional
+
+| Tool | Purpose |
+|------|---------|
+| [GitHub CLI (`gh`)](https://cli.github.com/) | PR creation suggestions from commit checkpoints |
+
+## Install by Platform
+
+### macOS
+
+macOS ships bash 3.2 (2007) due to GPLv3 licensing. The commit hooks require
+bash 4+. Install a current version via Homebrew:
+
+```bash
+brew install bash jq
+# Optional:
+brew install gh
+```
+
+The Homebrew bash installs to `/opt/homebrew/bin/bash` (Apple Silicon) or
+`/usr/local/bin/bash` (Intel). The hook scripts use `#!/usr/bin/env bash` which
+resolves to the first `bash` on `$PATH`. Ensure Homebrew's bin directory appears
+before `/bin` in your `$PATH` (Homebrew's installer does this by default).
+
+### Linux (Debian / Ubuntu)
+
+```bash
+sudo apt update && sudo apt install -y jq
+# Optional:
+sudo apt install -y gh
+```
+
+Bash 4+ and git are pre-installed on most Linux distributions.
+
+### Linux (Fedora / RHEL)
+
+```bash
+sudo dnf install -y jq
+# Optional:
+sudo dnf install -y gh
+```
+
+### Windows
+
+Not currently supported. See the project README for WSL workaround.
+
+## Quick Setup via Claude Code
+
+Already have Claude Code? Paste the following into a Claude Code session and it
+will detect your platform, check what is missing, and install it:
+
+> Check if these tools are installed and install any that are missing:
+> - git 2.20+
+> - jq 1.6+
+> - bash 4.0+ (on macOS, the system bash is 3.2 -- needs brew install bash)
+> - gh CLI (optional, for PR creation)
+> Then run ./install.sh in this repo to deploy the agents.
+
+## Verify Your Setup
+
+```bash
+bash --version   # Should show 4.0+
+git --version    # Should show 2.20+
+jq --version     # Should show 1.6+
+gh --version     # Optional, should show 2.x+
+```
+```
+
+Also add a prerequisites row to the "User-Facing" table in `docs/architecture.md`:
+
+```markdown
+| [Prerequisites](prerequisites.md) | Required CLI tools, per-platform installation, setup verification |
+```
+
+And add a "Prerequisites" section to the README after the install code block:
+
+```markdown
+### Prerequisites
+
+The install script needs only `git`. The commit workflow hooks need additional tools:
+
+| Tool | Version | Required For | Install |
+|------|---------|--------------|---------|
+| git | 2.20+ | Core | Pre-installed on macOS (`xcode-select --install`). `sudo apt install git` on Ubuntu. |
+| bash | 4.0+ | Commit hooks | macOS ships 3.2 -- run `brew install bash`. Pre-installed on Linux. |
+| jq | 1.6+ | Commit hooks | `brew install jq` (macOS). `sudo apt install jq` (Ubuntu). |
+| gh | 2.0+ | PR suggestions (optional) | `brew install gh` (macOS). See [cli.github.com](https://cli.github.com). |
+
+Or paste the [quick setup prompt](docs/prerequisites.md#quick-setup-via-claude-code) into Claude Code and it will install what is missing.
+```
+
+### Prompt 3: Achieving Cross-Platform Stability
+
+Use this prompt in a future `/nefario` session when ready to do the script hardening work:
+
+```
+Harden the despicable-agents shell scripts for cross-platform stability. Scope:
+
+1. Fix bash 4+ features in .claude/hooks/commit-point-check.sh:
+   - Replace `local -A seen_paths` (associative array) with file-based dedup
+     using `awk '!seen[$0]++'` or `sort -u` on a temp file
+   - Replace `local -a var=()` with `local var=""` and newline-delimited
+     processing via `while read` loops
+   - Verify the result works on bash 3.2 (test with: env BASH=/bin/bash bash script.sh on macOS)
+
+2. Add dependency guards to both hook scripts (.claude/hooks/):
+   - At the top of main(), check `command -v jq >/dev/null 2>&1` -- if missing,
+     write a one-time warning to stderr and exit 0
+   - Check BASH_VERSINFO[0] >= 4 -- if too old, write warning to stderr and exit 0
+   - Guards must be before any jq or bash 4+ usage
+
+3. Standardize all temp file paths to ${TMPDIR:-/tmp}:
+   - In .claude/hooks/track-file-changes.sh (ledger path)
+   - In .claude/hooks/commit-point-check.sh (ledger, defer marker, declined marker,
+     nefario status check)
+   - In skills/nefario/SKILL.md (status files, session-id, PR body temp)
+   - Define TEMP_BASE="${TMPDIR:-/tmp}" once at the top of each script
+   - CRITICAL: all files must use the same base path -- hooks and SKILL.md share
+     file paths. Verify with grep that no bare /tmp/ references remain.
+
+4. Add CRLF normalization to ledger writes in track-file-changes.sh:
+   - Pipe through `tr -d '\r'` before appending to ledger
+
+5. Replace `echo -e` with `printf` in install.sh for portability.
+
+Do NOT add Windows-specific code (no icacls, no junction points, no PowerShell).
+Do NOT add an install.sh check subcommand (separate task).
+Do NOT modify the install.sh symlink mechanism.
+Run shellcheck on all modified .sh files before committing.
+```

--- a/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/prompt.md
+++ b/docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check/prompt.md
@@ -1,0 +1,7 @@
+check if we are fine on all platforms and if not, what it would take to be safe on windows, macOS, linux
+we should think about adding documentation disclaimers that this is mac-only until we have that fixed (if the answer is "not yet")
+also think about documenting all command line tools that are expected to be available
+in the report, include prompts for
+- the docs disclaimer for platform specificity for now
+- documentation on required command line tools and how to install them ("ask claude code to do it for you, just paste the list")
+- achieving cross-platform stability


### PR DESCRIPTION
## Summary

Advisory report from a 4-specialist audit (iac-minion, devx-minion, software-docs-minion, security-minion) on cross-platform compatibility of despicable-agents shell scripts, hooks, and deployment model.

**Key findings:**
- macOS: works with Homebrew bash; stock bash 3.2 has a latent bug in commit hooks
- Linux: fully supported
- Windows: not supported (POSIX symlink dependency)
- jq is an undocumented hard dependency

**Recommendation:** Documentation first, code changes later (per YAGNI).

Full report: `docs/history/nefario-reports/2026-02-13-142612-cross-platform-compatibility-check.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)