### PR TITLE
feat(nefario): skip Phase 3/3.5 compaction checkpoints when NEFARIO_HEADLESS=1

### DIFF
--- a/skills/nefario/SKILL.md
+++ b/skills/nefario/SKILL.md
@@ -849,7 +849,19 @@ count, execution order) in session context. **Proceed to Phase 3.5
 
 ### Compaction Checkpoint
 
-After writing the synthesis to the scratch file, perform these steps in order:
+**Headless mode skip**: If the environment variable `NEFARIO_HEADLESS=1` is set
+(check via `Bash` tool: `printenv NEFARIO_HEADLESS`), SKIP THIS ENTIRE CHECKPOINT.
+Do not call `pbcopy`. Do not print any "compaction prompt copied" / "paste the
+command below" / "type continue" text. Your immediate next action MUST be the
+Phase 3.5 reviewer Agent invocations. The rationale: in headless invocations
+(e.g., `claude -p` for autonomous build loops), no human is present to paste
+the `/compact` command, and emitting the checkpoint message is interpreted by
+the model as an end-of-turn signal, which kills the cycle mid-orchestration.
+The fresh-context-per-cycle pattern that headless drivers use makes
+intra-cycle compaction structurally unnecessary.
+
+Interactive mode (default): after writing the synthesis to the scratch file,
+perform these steps in order:
 
 <!-- The <system_warning> token usage format ("Token usage: {used}/{total};
      {remaining} remaining") is empirically observed Claude Code behavior, not a
@@ -1377,7 +1389,15 @@ Follow these steps exactly. **Global cap: 2 revision rounds total.**
 
 ### Compaction Checkpoint
 
-After processing all review verdicts, perform these steps in order:
+**Headless mode skip**: If `NEFARIO_HEADLESS=1` is set (check via `Bash` tool:
+`printenv NEFARIO_HEADLESS`), SKIP THIS ENTIRE CHECKPOINT. Do not call
+`pbcopy`. Do not print "compaction prompt copied" / "paste the command below"
+/ "type continue" text. Your immediate next action MUST be the Phase 4
+execution dispatches from the synthesized plan. See the Phase 3 checkpoint
+above for full rationale.
+
+Interactive mode (default): after processing all review verdicts, perform
+these steps in order:
 
 Extract context usage from the most recent `<system_warning>` in the conversation
 (same extraction and fallback as the Phase 3 checkpoint above).


### PR DESCRIPTION
## Summary

When `NEFARIO_HEADLESS=1` is set, the Phase 3 and Phase 3.5 compaction checkpoints in nefario's SKILL.md skip silently. The orchestrator proceeds directly to the next phase (3.5 reviewers or Phase 4 execution) instead of emitting the "compaction prompt copied to clipboard / paste this and type continue" message.

## Why

In headless invocations (e.g., `claude -p` for autonomous build loops), no human is present to paste the `/compact` command. The model emits nefario's checkpoint text verbatim, interprets the emission as end-of-turn, and exits — killing the cycle mid-orchestration after Phase 3 synthesis.

Forensic evidence from session jsonl analysis of an autonomous build experiment: 2 of the last 23 cycles exited cleanly with no `CYCLE-N-COMPLETE` marker because they hit exactly this failure mode. Last text in both cases (verbatim):

> *"Phase 3 complete. Compaction prompt copied to clipboard. To compact: paste the command below, then type `continue` now -- it will run after compaction finishes."*

Sessions had completed Phase 1 (nefario meta-plan) + Phase 2 (4-6 specialists) + Phase 3 (synthesis), then died at the checkpoint instead of proceeding to Phase 3.5 reviewers.

## Behavior matrix

| `NEFARIO_HEADLESS` | Phase 3 checkpoint | Phase 3.5 checkpoint |
|---|---|---|
| unset (default) | emit message, wait for user | emit message, wait for user |
| `1` | skip silently, proceed to Phase 3.5 reviewers | skip silently, proceed to Phase 4 execution |

The interactive default is unchanged. The pattern matches the existing `advisory-mode` skip-checkpoint logic (line 911 in the unchanged file).

## Test plan

- [ ] Manual: run an interactive `/nefario` task in Claude Code without the env var — checkpoint message appears as before
- [ ] Manual: run `NEFARIO_HEADLESS=1 claude -p` against a small task that requires Phase 3.5 review — orchestration proceeds without the checkpoint emission
- [ ] Forensic: re-run the failed-cycle reproduction (a `/nefario` task that previously died at Phase 3) under headless mode and verify Phase 3.5 reviewers are invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)